### PR TITLE
Implement Asynchronous I/O Path for Volumes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,8 @@ add_subdirectory(src/common)
 add_subdirectory(src/network) # Added network
 add_subdirectory(src/core)    # Added core (for spdk_manager)
 add_subdirectory(src/bdev)    # Added bdev
-add_subdirectory(src/storage) # Added storage (for disk_manager)
+add_subdirectory(src/io)      # Added io (for xsan_io)
+add_subdirectory(src/storage) # Added storage (for disk_manager, volume_manager)
 add_subdirectory(src/main)    # Main executable likely defined here
 add_subdirectory(tests)
 

--- a/src/include/xsan_io.h
+++ b/src/include/xsan_io.h
@@ -1,0 +1,140 @@
+#ifndef XSAN_IO_H
+#define XSAN_IO_H
+
+#include "xsan_types.h" // For xsan_error_t, xsan_volume_id_t, xsan_disk_id_t
+#include "xsan_storage.h" // For xsan_volume_t, xsan_disk_t (potentially needed for context)
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h> // For size_t
+
+// Forward declarations for SPDK types used in xsan_io_request_t if not included directly
+struct spdk_bdev_desc;
+struct spdk_io_channel;
+struct spdk_bdev_io;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief User-level I/O completion callback function type.
+ * This callback is invoked when an asynchronous I/O operation initiated by
+ * XSAN (e.g., xsan_volume_read_async) completes.
+ *
+ * @param cb_arg The user-provided context argument passed during the async call.
+ * @param status XSAN_OK if the I/O was successful, or an xsan_error_t code on failure.
+ */
+typedef void (*xsan_user_io_completion_cb_t)(void *cb_arg, xsan_error_t status);
+
+/**
+ * @brief Structure to encapsulate an XSAN I/O request.
+ * This structure tracks all necessary information for an asynchronous I/O operation
+ * through its lifecycle, from submission to completion.
+ * An instance of this is typically allocated per I/O operation.
+ */
+typedef struct xsan_io_request {
+    // --- User-provided parameters / context ---
+    xsan_volume_id_t target_volume_id;  ///< ID of the target logical volume (if applicable)
+    xsan_disk_id_t target_disk_id;      ///< ID of the target physical disk (resolved from volume or direct)
+    char target_bdev_name[XSAN_MAX_NAME_LEN]; ///< Name of the target SPDK bdev
+
+    bool is_read_op;                    ///< True for read, false for write
+
+    void *user_buffer;                  ///< User's original data buffer (for final copy on read, or source on write)
+    uint64_t user_buffer_offset_bytes;  ///< Offset within the user_buffer (if handling partial block copies)
+
+    uint64_t offset_bytes;              ///< Byte offset for the I/O operation on the target (volume or disk)
+    uint64_t length_bytes;              ///< Length of the I/O operation in bytes
+
+    // For block-based operations (derived from offset_bytes/length_bytes and block_size)
+    uint64_t offset_blocks;             ///< Starting block number
+    uint32_t num_blocks;                ///< Number of blocks
+    uint32_t block_size_bytes;          ///< Block size for this operation
+
+    xsan_user_io_completion_cb_t user_cb; ///< User's callback function for completion notification
+    void *user_cb_arg;                  ///< Argument for the user's callback
+
+    // --- Internal state and resources ---
+    void *dma_buffer;                   ///< Pointer to DMA-safe buffer used for SPDK I/O
+    bool dma_buffer_is_internal;        ///< True if dma_buffer was allocated internally by xsan_io module
+    size_t dma_buffer_size;             ///< Size of the allocated dma_buffer
+
+    struct spdk_bdev_desc *bdev_desc;   ///< SPDK bdev descriptor (owned by the IO request or managed externally)
+    struct spdk_io_channel *io_channel; ///< SPDK I/O channel (owned by the IO request or managed externally)
+    bool own_spdk_resources;            ///< True if this request opened/got the bdev_desc and io_channel and should release them
+
+    xsan_error_t status;                ///< Final status of the I/O operation
+
+    // Could add retry counts, timestamps, etc. for more advanced features
+    // int retries_left;
+
+    // For linking into lists if the IO scheduler manages queues of requests
+    struct xsan_io_request *next;
+    struct xsan_io_request *prev;
+
+    // Potentially a pointer back to the I/O scheduler or volume context if needed
+    // void *parent_scheduler;
+
+} xsan_io_request_t;
+
+
+/**
+ * @brief Allocates and initializes an xsan_io_request_t structure.
+ *
+ * @param target_volume_id ID of the volume (can be zeroed if targeting a disk directly).
+ * @param user_buffer User's data buffer.
+ * @param offset_bytes Byte offset for the I/O.
+ * @param length_bytes Length of the I/O in bytes.
+ * @param block_size_bytes The block size to be used for calculating num_blocks and offset_blocks.
+ * @param is_read True for a read operation, false for write.
+ * @param user_cb User completion callback.
+ * @param user_cb_arg Argument for user callback.
+ * @return Pointer to a new xsan_io_request_t, or NULL on allocation failure.
+ *         The caller is responsible for populating target_disk_id/target_bdev_name
+ *         and SPDK resources (desc, channel) or using functions that manage them.
+ */
+xsan_io_request_t *xsan_io_request_create(
+    xsan_volume_id_t target_volume_id,
+    void *user_buffer,
+    uint64_t offset_bytes,
+    uint64_t length_bytes,
+    uint32_t block_size_bytes,
+    bool is_read,
+    xsan_user_io_completion_cb_t user_cb,
+    void *user_cb_arg
+);
+
+/**
+ * @brief Frees an xsan_io_request_t structure.
+ * If dma_buffer_is_internal is true, it also frees the internal DMA buffer.
+ * It does NOT automatically close/put bdev_desc or io_channel unless own_spdk_resources is true
+ * and specific logic is added for that. Resource management for desc/channel is complex.
+ *
+ * @param io_req The I/O request to free.
+ */
+void xsan_io_request_free(xsan_io_request_t *io_req);
+
+/**
+ * @brief Submits an I/O request to the appropriate SPDK bdev.
+ * This is the core function that translates an XSAN I/O request to an SPDK I/O.
+ * It handles DMA buffer preparation (if needed and configured in io_req),
+ * and calls the underlying SPDK async read/write block functions.
+ * The bdev_desc and io_channel must be valid and set in io_req before calling this,
+ * or this function needs to acquire them (which adds complexity).
+ *
+ * This function MUST be called from an SPDK thread.
+ *
+ * @param io_req The fully populated I/O request.
+ * @return XSAN_OK if the I/O was successfully submitted to SPDK.
+ *         XSAN_ERROR_INVALID_PARAM if io_req or its critical members are invalid.
+ *         XSAN_ERROR_OUT_OF_MEMORY if SPDK cannot allocate an spdk_bdev_io.
+ *         Other XSAN_ERROR codes for SPDK submission failures.
+ */
+xsan_error_t xsan_io_submit_request_to_bdev(xsan_io_request_t *io_req);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XSAN_IO_H

--- a/src/include/xsan_storage.h
+++ b/src/include/xsan_storage.h
@@ -89,9 +89,13 @@ typedef struct xsan_disk {
     uint32_t optimal_io_boundary_blocks;       ///< Optimal I/O boundary in blocks
     bool has_write_cache;                      ///< True if write cache is enabled
 
+    struct spdk_bdev_desc *bdev_descriptor;    ///< SPDK bdev descriptor, opened by disk_manager
+                                               ///< NULL if not opened or could not be opened.
+
     // Linkage for disk manager's internal list (example, actual list mgmt may differ)
-    struct xsan_disk *next;
-    struct xsan_disk *prev;
+    // These are not needed if xsan_list stores void* to xsan_disk_t instances.
+    // struct xsan_disk *next;
+    // struct xsan_disk *prev;
 
     // Runtime information (optional, could be managed elsewhere)
     // uint64_t used_bytes;

--- a/src/include/xsan_volume_manager.h
+++ b/src/include/xsan_volume_manager.h
@@ -135,7 +135,56 @@ xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
                                              xsan_volume_id_t volume_id,
                                              uint64_t logical_block_idx,
                                              xsan_disk_id_t *out_disk_id,
-                                             uint64_t *out_physical_block_idx);
+                                             uint64_t *out_physical_block_idx,
+                                             uint32_t *out_physical_block_size); // Also return physical block size
+
+/**
+ * @brief Reads data asynchronously from a logical volume.
+ *
+ * @param vm The volume manager instance.
+ * @param volume_id The ID of the volume to read from.
+ * @param logical_byte_offset The starting byte offset within the logical volume.
+ * @param length_bytes The number of bytes to read.
+ * @param user_buf The buffer where the read data will be stored.
+ *                 This buffer might be used directly if DMA-safe and aligned, or data
+ *                 might be copied into it from an internal DMA buffer.
+ * @param user_cb The user's completion callback function.
+ * @param user_cb_arg Argument for the user's callback.
+ * @return XSAN_OK if the read operation was successfully submitted.
+ *         An xsan_error_t code on failure (e.g., volume not found, invalid params, submission error).
+ *         The actual I/O result is delivered via the user_cb.
+ */
+xsan_error_t xsan_volume_read_async(xsan_volume_manager_t *vm,
+                                    xsan_volume_id_t volume_id,
+                                    uint64_t logical_byte_offset,
+                                    uint64_t length_bytes,
+                                    void *user_buf,
+                                    xsan_user_io_completion_cb_t user_cb,
+                                    void *user_cb_arg);
+
+/**
+ * @brief Writes data asynchronously to a logical volume.
+ *
+ * @param vm The volume manager instance.
+ * @param volume_id The ID of the volume to write to.
+ * @param logical_byte_offset The starting byte offset within the logical volume.
+ * @param length_bytes The number of bytes to write.
+ * @param user_buf The buffer containing the data to write.
+ *                 This buffer might be used directly or data copied from it to an internal DMA buffer.
+ * @param user_cb The user's completion callback function.
+ * @param user_cb_arg Argument for the user's callback.
+ * @return XSAN_OK if the write operation was successfully submitted.
+ *         An xsan_error_t code on failure.
+ *         The actual I/O result is delivered via the user_cb.
+ */
+xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm,
+                                     xsan_volume_id_t volume_id,
+                                     uint64_t logical_byte_offset,
+                                     uint64_t length_bytes,
+                                     const void *user_buf, // const for write
+                                     xsan_user_io_completion_cb_t user_cb,
+                                     void *user_cb_arg);
+
 
 // Potentially add functions for resizing volumes, snapshots, etc. in the future.
 

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(xsan_io STATIC
+    xsan_io.c
+)
+
+target_include_directories(xsan_io PUBLIC
+    ${CMAKE_SOURCE_DIR}/include      # For xsan_types.h, xsan_storage.h etc.
+    ${CMAKE_SOURCE_DIR}/src/include  # For xsan_io.h, xsan_bdev.h etc.
+)
+
+# Dependencies for xsan_io library itself
+target_link_libraries(xsan_io PUBLIC # Or INTERFACE if only headers are needed by consumers
+    xsan_bdev       # Uses xsan_bdev_dma_malloc/free
+    xsan_common     # For error types
+    xsan_utils      # For logging, memory allocation
+)
+
+# SPDK includes are handled globally
+# SPDK libraries linked by final executable

--- a/src/io/xsan_io.c
+++ b/src/io/xsan_io.c
@@ -1,0 +1,276 @@
+#include "xsan_io.h"
+#include "xsan_bdev.h"         // For xsan_bdev_dma_malloc/free, xsan_bdev_get_buf_align
+#include "xsan_memory.h"       // For XSAN_MALLOC, XSAN_FREE
+#include "xsan_error.h"
+#include "xsan_log.h"
+#include "xsan_string_utils.h" // For xsan_strcpy_safe
+
+#include "spdk/bdev.h"
+#include "spdk/env.h"          // For spdk_dma_malloc/free (though wrapped)
+#include "spdk/thread.h"       // For spdk_get_thread, spdk_io_channel related if not via bdev_desc
+#include "spdk/bdev_module.h"  // For spdk_bdev_open_ext, spdk_bdev_close
+
+xsan_io_request_t *xsan_io_request_create(
+    xsan_volume_id_t target_volume_id,
+    void *user_buffer,
+    uint64_t offset_bytes,
+    uint64_t length_bytes,
+    uint32_t block_size_bytes, // Logical block size for this IO
+    bool is_read,
+    xsan_user_io_completion_cb_t user_cb,
+    void *user_cb_arg) {
+
+    if (!user_buffer || length_bytes == 0 || block_size_bytes == 0 || !user_cb) {
+        XSAN_LOG_ERROR("Invalid parameters for xsan_io_request_create.");
+        return NULL;
+    }
+    if ((offset_bytes % block_size_bytes != 0) || (length_bytes % block_size_bytes != 0)) {
+        XSAN_LOG_ERROR("Offset (%lu) or length (%lu) not aligned to block size (%u).",
+                       offset_bytes, length_bytes, block_size_bytes);
+        // For simplicity, initial version requires alignment.
+        // Future: Could handle partial block reads/writes by reading full blocks internally.
+        return NULL;
+    }
+
+    xsan_io_request_t *io_req = (xsan_io_request_t *)XSAN_MALLOC(sizeof(xsan_io_request_t));
+    if (!io_req) {
+        XSAN_LOG_ERROR("Failed to allocate memory for xsan_io_request_t.");
+        return NULL;
+    }
+
+    memset(io_req, 0, sizeof(xsan_io_request_t));
+
+    memcpy(&io_req->target_volume_id, &target_volume_id, sizeof(xsan_volume_id_t));
+    // target_disk_id and target_bdev_name will be populated by the volume manager before submission.
+
+    io_req->is_read_op = is_read;
+    io_req->user_buffer = user_buffer;
+    io_req->offset_bytes = offset_bytes;
+    io_req->length_bytes = length_bytes;
+
+    io_req->block_size_bytes = block_size_bytes;
+    io_req->offset_blocks = offset_bytes / block_size_bytes;
+    io_req->num_blocks = length_bytes / block_size_bytes;
+
+    io_req->user_cb = user_cb;
+    io_req->user_cb_arg = user_cb_arg;
+
+    io_req->status = XSAN_OK; // Initial status
+    io_req->dma_buffer = NULL;
+    io_req->dma_buffer_is_internal = false;
+    io_req->dma_buffer_size = 0;
+    io_req->bdev_desc = NULL;
+    io_req->io_channel = NULL;
+    io_req->own_spdk_resources = false; // Default to not owning, submitter will manage or set this
+
+    return io_req;
+}
+
+void xsan_io_request_free(xsan_io_request_t *io_req) {
+    if (!io_req) {
+        return;
+    }
+    if (io_req->dma_buffer_is_internal && io_req->dma_buffer) {
+        xsan_bdev_dma_free(io_req->dma_buffer);
+    }
+    // If own_spdk_resources was true, desc and channel should have been released in completion cb
+    // or before freeing the request if submission failed.
+    XSAN_FREE(io_req);
+}
+
+// Static SPDK I/O completion callback
+static void _xsan_io_spdk_completion_cb(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
+    xsan_io_request_t *io_req = (xsan_io_request_t *)cb_arg;
+
+    if (!io_req) {
+        XSAN_LOG_ERROR("SPDK completion callback received NULL cb_arg (xsan_io_request_t).");
+        if (bdev_io) spdk_bdev_free_io(bdev_io);
+        return;
+    }
+
+    XSAN_LOG_DEBUG("SPDK IO completed for bdev '%s', op: %s, success: %d",
+                   io_req->target_bdev_name, io_req->is_read_op ? "READ" : "WRITE", success);
+
+    io_req->status = success ? XSAN_OK : XSAN_ERROR_IO;
+
+    if (success && io_req->is_read_op && io_req->dma_buffer_is_internal && io_req->dma_buffer) {
+        if (io_req->user_buffer) {
+            // Assuming length_bytes in io_req is the actual amount to copy
+            memcpy(io_req->user_buffer, io_req->dma_buffer, io_req->length_bytes);
+        } else {
+            XSAN_LOG_ERROR("Internal DMA read successful for bdev '%s' but user_buffer is NULL in io_req.", io_req->target_bdev_name);
+            io_req->status = XSAN_ERROR_INVALID_PARAM; // Or internal error
+        }
+    }
+
+    spdk_bdev_free_io(bdev_io); // Always free the SPDK bdev_io
+
+    // Release SPDK resources if this IO request "owns" them
+    if (io_req->own_spdk_resources) {
+        if (io_req->io_channel) {
+            spdk_put_io_channel(io_req->io_channel);
+            io_req->io_channel = NULL;
+        }
+        if (io_req->bdev_desc) {
+            spdk_bdev_close(io_req->bdev_desc);
+            io_req->bdev_desc = NULL;
+        }
+    }
+
+    // Call the user's completion callback
+    if (io_req->user_cb) {
+        io_req->user_cb(io_req->user_cb_arg, io_req->status);
+    }
+
+    // Free the xsan_io_request_t itself
+    xsan_io_request_free(io_req);
+}
+
+xsan_error_t xsan_io_submit_request_to_bdev(xsan_io_request_t *io_req) {
+    if (!io_req || !io_req->user_cb || !io_req->target_bdev_name[0] || io_req->num_blocks == 0) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    if (spdk_get_thread() == NULL) {
+        XSAN_LOG_ERROR("xsan_io_submit_request_to_bdev must be called from an SPDK thread.");
+        return XSAN_ERROR_THREAD_CONTEXT;
+    }
+
+    xsan_error_t err = XSAN_OK;
+    struct spdk_bdev *bdev = NULL;
+    void *payload_buffer_for_spdk; // This will be the DMA safe buffer
+
+    // Step 1: Get SPDK bdev handle
+    bdev = spdk_bdev_get_by_name(io_req->target_bdev_name);
+    if (!bdev) {
+        XSAN_LOG_ERROR("Bdev '%s' not found for IO submission.", io_req->target_bdev_name);
+        return XSAN_ERROR_NOT_FOUND;
+    }
+
+    // Step 2: Open bdev descriptor and get IO channel (if not already provided in io_req)
+    // For this implementation, we open/close desc and get/put channel per request.
+    // This can be optimized later by caching them (e.g., in xsan_disk_t or per-thread).
+    if (!io_req->bdev_desc) {
+        int rc_open = spdk_bdev_open_ext(io_req->target_bdev_name, true, NULL, NULL, &io_req->bdev_desc);
+        if (rc_open != 0) {
+            XSAN_LOG_ERROR("Failed to open bdev '%s': %s (rc=%d)", io_req->target_bdev_name, spdk_strerror(-rc_open), rc_open);
+            return xsan_error_from_errno(-rc_open);
+        }
+        io_req->own_spdk_resources = true; // This request is responsible for closing desc
+    }
+
+    if (!io_req->io_channel) {
+        io_req->io_channel = spdk_bdev_get_io_channel(io_req->bdev_desc);
+        if (!io_req->io_channel) {
+            XSAN_LOG_ERROR("Failed to get I/O channel for bdev '%s'", io_req->target_bdev_name);
+            if (io_req->own_spdk_resources && io_req->bdev_desc) { // Clean up desc if we opened it
+                spdk_bdev_close(io_req->bdev_desc);
+                io_req->bdev_desc = NULL;
+            }
+            return XSAN_ERROR_IO;
+        }
+        // Note: If we got the channel, own_spdk_resources should also cover putting it back.
+    }
+
+
+    // Step 3: Prepare DMA buffer if needed
+    uint32_t physical_bdev_block_size = spdk_bdev_get_block_size(bdev);
+    size_t physical_io_size = (size_t)io_req->num_blocks * physical_bdev_block_size;
+    // This assumes num_blocks in io_req is in terms of physical_bdev_block_size.
+    // If io_req->block_size_bytes is different, num_blocks and offset_blocks need conversion
+    // *before* this function, or this function needs to handle it.
+    // For now, assume io_req->num_blocks and io_req->offset_blocks are already in terms of physical_bdev_block_size.
+    // This means io_req->length_bytes should equal physical_io_size.
+    if(io_req->length_bytes != physical_io_size) {
+        XSAN_LOG_ERROR("Mismatch: io_req length %lu != calculated physical IO size %zu for bdev %s. Ensure num_blocks is based on physical block size.",
+                        io_req->length_bytes, physical_io_size, io_req->target_bdev_name);
+        // Clean up resources if owned
+        if (io_req->own_spdk_resources) {
+            if (io_req->io_channel) spdk_put_io_channel(io_req->io_channel);
+            if (io_req->bdev_desc) spdk_bdev_close(io_req->bdev_desc);
+        }
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+
+    // For simplicity, assume we always use an internal DMA buffer for now if not provided one.
+    // A more advanced check would be: if (spdk_vtophys(io_req->user_buffer) == SPDK_VTOPHYS_ERROR || alignment_check_fails)
+    // For now, let's use the 'dma_buffer_is_internal' field as a hint if caller wants internal alloc.
+    // If io_req->dma_buffer is already set and dma_buffer_is_internal is false, use it.
+    // Otherwise, allocate.
+
+    if (io_req->dma_buffer && !io_req->dma_buffer_is_internal) { // User provided DMA buffer
+        payload_buffer_for_spdk = io_req->dma_buffer;
+    } else { // Need to allocate internal DMA buffer
+        size_t bdev_align = spdk_bdev_get_buf_align(bdev);
+        io_req->dma_buffer = xsan_bdev_dma_malloc(physical_io_size, bdev_align);
+        if (!io_req->dma_buffer) {
+            XSAN_LOG_ERROR("Failed to allocate DMA buffer (size %zu) for IO on bdev '%s'", physical_io_size, io_req->target_bdev_name);
+            if (io_req->own_spdk_resources) {
+                if (io_req->io_channel) spdk_put_io_channel(io_req->io_channel);
+                if (io_req->bdev_desc) spdk_bdev_close(io_req->bdev_desc);
+            }
+            return XSAN_ERROR_OUT_OF_MEMORY;
+        }
+        io_req->dma_buffer_is_internal = true;
+        io_req->dma_buffer_size = physical_io_size;
+        payload_buffer_for_spdk = io_req->dma_buffer;
+
+        if (!io_req->is_read_op) { // For write, copy user data to internal DMA buffer
+            if (io_req->user_buffer) { // Should always be true for write
+                memcpy(payload_buffer_for_spdk, io_req->user_buffer, io_req->length_bytes);
+            } else {
+                 XSAN_LOG_ERROR("User buffer is NULL for write operation with internal DMA buffer. Bdev: %s", io_req->target_bdev_name);
+                 // Cleanup and error (as above)
+                if (io_req->own_spdk_resources) {
+                    if (io_req->io_channel) spdk_put_io_channel(io_req->io_channel);
+                    if (io_req->bdev_desc) spdk_bdev_close(io_req->bdev_desc);
+                }
+                xsan_bdev_dma_free(io_req->dma_buffer); // Free the one we just allocated
+                io_req->dma_buffer = NULL;
+                return XSAN_ERROR_INVALID_PARAM;
+            }
+        }
+    }
+
+    // Step 4: Submit asynchronous I/O to SPDK
+    int spdk_rc;
+    if (io_req->is_read_op) {
+        spdk_rc = spdk_bdev_read_blocks(io_req->bdev_desc, io_req->io_channel, payload_buffer_for_spdk,
+                                        io_req->offset_blocks, io_req->num_blocks,
+                                        _xsan_io_spdk_completion_cb, io_req);
+    } else {
+        spdk_rc = spdk_bdev_write_blocks(io_req->bdev_desc, io_req->io_channel, payload_buffer_for_spdk,
+                                         io_req->offset_blocks, io_req->num_blocks,
+                                         _xsan_io_spdk_completion_cb, io_req);
+    }
+
+    // Step 5: Handle SPDK submission result
+    if (spdk_rc != 0) {
+        XSAN_LOG_ERROR("Failed to submit SPDK %s request for bdev '%s': %s (rc=%d)",
+                       io_req->is_read_op ? "read" : "write", io_req->target_bdev_name, spdk_strerror(-spdk_rc), spdk_rc);
+        err = (spdk_rc == -ENOMEM) ? XSAN_ERROR_OUT_OF_MEMORY : XSAN_ERROR_IO;
+
+        // Critical: If submission failed, the SPDK completion callback will NOT be called.
+        // So, we must clean up resources here and then call the user's callback with error, then free io_req.
+        if (io_req->dma_buffer_is_internal && io_req->dma_buffer) {
+            xsan_bdev_dma_free(io_req->dma_buffer);
+            io_req->dma_buffer = NULL;
+        }
+        if (io_req->own_spdk_resources) {
+            if (io_req->io_channel) spdk_put_io_channel(io_req->io_channel);
+            if (io_req->bdev_desc) spdk_bdev_close(io_req->bdev_desc);
+        }
+        // Set status before calling user callback
+        io_req->status = err;
+        if(io_req->user_cb) io_req->user_cb(io_req->user_cb_arg, io_req->status);
+        xsan_io_request_free(io_req); // Free the request itself
+        return err; // Return error to the submitter (e.g. volume manager)
+    }
+
+    // If spdk_rc == 0, submission was successful. SPDK completion callback will handle cleanup.
+    return XSAN_OK;
+}
+
+// CMakeLists.txt in src/ (or new src/io/) will need to add xsan_io.c
+// And src/main/CMakeLists.txt will link the new xsan_io library.

--- a/src/main/xsan_node.c
+++ b/src/main/xsan_node.c
@@ -1,30 +1,218 @@
 #include "xsan_log.h"
-#include "xsan_config.h"        // May not be used directly here, but good to have
+#include "xsan_config.h"
 #include "xsan_spdk_manager.h"
 #include "xsan_bdev.h"
-#include "xsan_disk_manager.h"  // Added
-#include "xsan_volume_manager.h"// Added
-#include "xsan_error.h"         // For error strings
-#include "xsan_string_utils.h"  // For xsan_strcpy_safe if needed
+#include "xsan_disk_manager.h"
+#include "xsan_volume_manager.h"
+#include "xsan_io.h" // For xsan_user_io_completion_cb_t
+#include "xsan_error.h"
+#include "xsan_string_utils.h"
 
 #include <stdio.h>
-#include <stdlib.h>             // For EXIT_SUCCESS, EXIT_FAILURE
-#include <string.h>             // For memset, strstr, memcmp
-#include <unistd.h>             // For sleep (debugging)
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-// SPDK Headers needed for this test/main file specifically
-#include "spdk/uuid.h"          // For spdk_uuid_fmt_lower, SPDK_UUID_STRING_LEN, spdk_uuid_is_null
-#include "spdk/env.h"           // For spdk_dma_malloc/free (though wrapped by xsan_bdev)
+#include "spdk/uuid.h"
+#include "spdk/env.h"
 
-/**
- * @brief Main application function executed on an SPDK reactor thread.
- * This function is passed to xsan_spdk_manager_start_app.
- *
- * @param arg1 Custom argument passed from xsan_spdk_manager_start_app (currently NULL).
- * @param rc Return code from the SPDK framework's internal start process. 0 on success.
- */
+
+// --- Async I/O Test Context and Callbacks ---
+typedef struct {
+    xsan_volume_manager_t *vm;
+    xsan_disk_manager_t *dm; // To find disk for bdev name if needed
+    xsan_volume_id_t volume_id_to_test;
+    char target_bdev_name_for_log[XSAN_MAX_NAME_LEN];
+    uint32_t io_block_size; // Block size used for this specific I/O test
+    size_t dma_alignment;
+
+    void *write_buffer_dma;
+    void *read_buffer_dma;
+
+    enum {
+        ASYNC_IO_TEST_IDLE,
+        ASYNC_IO_TEST_WRITE_SUBMITTED,
+        ASYNC_IO_TEST_READ_SUBMITTED,
+        ASYNC_IO_TEST_VERIFY_DONE, // Successfully completed and verified
+        ASYNC_IO_TEST_FAILED       // An error occurred
+    } test_state;
+
+    int outstanding_io_ops; // Counter for pending async operations for this test
+    bool all_tests_finished_signal; // Signal to main SPDK thread function to proceed to cleanup
+} xsan_async_io_test_control_t;
+
+// Make it global for easy access in callbacks and the main SPDK app function.
+// In a real app, this context would be managed more carefully, perhaps per-test-suite.
+static xsan_async_io_test_control_t g_async_test_controller;
+
+// Forward declaration for the read part of the test
+static void _run_async_io_test_read_phase(xsan_async_io_test_control_t *test_ctrl);
+static void _finalize_and_stop_app_if_all_done(xsan_async_io_test_control_t *test_ctrl);
+
+
+static void _async_io_test_read_complete_cb(void *cb_arg, xsan_error_t status) {
+    xsan_async_io_test_control_t *test_ctrl = (xsan_async_io_test_control_t *)cb_arg;
+    test_ctrl->outstanding_io_ops--;
+
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+
+    if (status != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncTest] Read from volume %s FAILED: %s (code %d)",
+                       vol_id_str, xsan_error_string(status), status);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+    } else {
+        XSAN_LOG_INFO("[AsyncTest] Read from volume %s successful.", vol_id_str);
+        if (memcmp(test_ctrl->write_buffer_dma, test_ctrl->read_buffer_dma, test_ctrl->io_block_size) == 0) {
+            XSAN_LOG_INFO("SUCCESS: [AsyncTest] R/W data verification for volume %s PASSED!", vol_id_str);
+            test_ctrl->test_state = ASYNC_IO_TEST_VERIFY_DONE;
+        } else {
+            XSAN_LOG_ERROR("FAILURE: [AsyncTest] R/W data verification for volume %s FAILED!", vol_id_str);
+            // For debugging, one might print parts of the buffers here
+            test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        }
+    }
+    _finalize_and_stop_app_if_all_done(test_ctrl);
+}
+
+static void _run_async_io_test_read_phase(xsan_async_io_test_control_t *test_ctrl) {
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+    XSAN_LOG_DEBUG("[AsyncTest] Submitting async read for volume %s, offset 0, length %u...",
+                   vol_id_str, test_ctrl->io_block_size);
+
+    test_ctrl->test_state = ASYNC_IO_TEST_READ_SUBMITTED;
+    test_ctrl->outstanding_io_ops++;
+
+    xsan_error_t err = xsan_volume_read_async(test_ctrl->vm, test_ctrl->volume_id_to_test,
+                                              0, // logical byte offset
+                                              test_ctrl->io_block_size, // length bytes
+                                              test_ctrl->read_buffer_dma,
+                                              _async_io_test_read_complete_cb, test_ctrl);
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncTest] Failed to submit async read for volume %s: %s", vol_id_str, xsan_error_string(err));
+        test_ctrl->outstanding_io_ops--;
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+    }
+}
+
+static void _async_io_test_write_complete_cb(void *cb_arg, xsan_error_t status) {
+    xsan_async_io_test_control_t *test_ctrl = (xsan_async_io_test_control_t *)cb_arg;
+    test_ctrl->outstanding_io_ops--;
+
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+
+    if (status != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncTest] Write to volume %s FAILED: %s (code %d)",
+                       vol_id_str, xsan_error_string(status), status);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+    } else {
+        XSAN_LOG_INFO("[AsyncTest] Write to volume %s successful. Proceeding to read phase.", vol_id_str);
+        _run_async_io_test_read_phase(test_ctrl);
+        // Note: _finalize_and_stop_app_if_all_done will be called by read's completion
+    }
+}
+
+static void _start_async_io_test_on_volume(xsan_async_io_test_control_t *test_ctrl, xsan_volume_t *vol_to_test) {
+    if (!vol_to_test || vol_to_test->block_size_bytes == 0 || vol_to_test->num_blocks == 0) {
+        XSAN_LOG_ERROR("[AsyncTest] Invalid volume provided for test or volume has no space/zero block size.");
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+        return;
+    }
+
+    memcpy(&test_ctrl->volume_id_to_test, &vol_to_test->id, sizeof(xsan_volume_id_t));
+    test_ctrl->io_block_size = vol_to_test->block_size_bytes; // Use volume's logical block size for test I/O unit
+
+    // Need bdev name for alignment info (could also get physical block size from mapping if needed)
+    // This assumes simple mapping to first disk of the group for now to get a bdev name.
+    xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(test_ctrl->dm, vol_to_test->source_group_id);
+    if (!group || group->disk_count == 0) {
+        XSAN_LOG_ERROR("[AsyncTest] Volume '%s' has invalid or empty source group. Cannot get bdev for alignment.", vol_to_test->name);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+        return;
+    }
+    xsan_disk_t *first_disk_in_group = xsan_disk_manager_find_disk_by_id(test_ctrl->dm, group->disk_ids[0]);
+    if (!first_disk_in_group) {
+        XSAN_LOG_ERROR("[AsyncTest] Could not find first disk of group for volume '%s'.", vol_to_test->name);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+        return;
+    }
+    xsan_strcpy_safe(test_ctrl->target_bdev_name_for_log, first_disk_in_group->bdev_name, XSAN_MAX_NAME_LEN);
+    test_ctrl->dma_alignment = xsan_bdev_get_buf_align(first_disk_in_group->bdev_name);
+
+
+    test_ctrl->write_buffer_dma = xsan_bdev_dma_malloc(test_ctrl->io_block_size, test_ctrl->dma_alignment);
+    test_ctrl->read_buffer_dma = xsan_bdev_dma_malloc(test_ctrl->io_block_size, test_ctrl->dma_alignment);
+
+    if (!test_ctrl->write_buffer_dma || !test_ctrl->read_buffer_dma) {
+        XSAN_LOG_ERROR("[AsyncTest] Failed to allocate DMA buffers for async I/O test.");
+        if(test_ctrl->write_buffer_dma) xsan_bdev_dma_free(test_ctrl->write_buffer_dma);
+        if(test_ctrl->read_buffer_dma) xsan_bdev_dma_free(test_ctrl->read_buffer_dma);
+        test_ctrl->write_buffer_dma = NULL; test_ctrl->read_buffer_dma = NULL;
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+        return;
+    }
+
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+    snprintf((char*)test_ctrl->write_buffer_dma, test_ctrl->io_block_size, "XSAN Async Test! Vol %s", vol_id_str);
+    for(size_t k=strlen((char*)test_ctrl->write_buffer_dma); k < test_ctrl->io_block_size; ++k) {
+        ((char*)test_ctrl->write_buffer_dma)[k] = (char)((k % 250) + 5);
+    }
+    memset(test_ctrl->read_buffer_dma, 0xDD, test_ctrl->io_block_size); // Fill with a different pattern
+
+    XSAN_LOG_INFO("--- Starting Async R/W Test on Volume ID %s (bdev: '%s', io_block_size: %u) ---",
+                  vol_id_str, test_ctrl->target_bdev_name_for_log, test_ctrl->io_block_size);
+    XSAN_LOG_DEBUG("[AsyncTest] Submitting async write for volume %s, offset 0, length %u...", vol_id_str, test_ctrl->io_block_size);
+
+    test_ctrl->test_state = ASYNC_IO_TEST_WRITE_SUBMITTED;
+    test_ctrl->outstanding_io_ops++;
+    xsan_error_t err = xsan_volume_write_async(test_ctrl->vm, test_ctrl->volume_id_to_test,
+                                     0, // logical byte offset
+                                     test_ctrl->io_block_size, // length bytes
+                                     test_ctrl->write_buffer_dma,
+                                     _async_io_test_write_complete_cb, test_ctrl);
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncTest] Failed to submit async write for volume %s: %s", vol_id_str, xsan_error_string(err));
+        test_ctrl->outstanding_io_ops--;
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        _finalize_and_stop_app_if_all_done(test_ctrl);
+    }
+    // If submission OK, callbacks will drive the rest and eventually call _finalize_and_stop_app_if_all_done
+}
+
+static void _finalize_and_stop_app_if_all_done(xsan_async_io_test_control_t *test_ctrl) {
+    if (test_ctrl->outstanding_io_ops == 0) {
+        XSAN_LOG_INFO("[AsyncTest] Async I/O test sequence on volume %s finished with state: %d.",
+                      spdk_uuid_get_string((struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]),
+                      test_ctrl->test_state);
+
+        if(test_ctrl->write_buffer_dma) xsan_bdev_dma_free(test_ctrl->write_buffer_dma);
+        if(test_ctrl->read_buffer_dma) xsan_bdev_dma_free(test_ctrl->read_buffer_dma);
+        test_ctrl->write_buffer_dma = NULL;
+        test_ctrl->read_buffer_dma = NULL;
+
+        test_ctrl->all_tests_finished_signal = true; // Signal main SPDK app func
+        // Do NOT call xsan_spdk_manager_request_app_stop() directly from a SPDK IO completion callback
+        // if that callback might be on a different thread than the main app thread that needs to clean up.
+        // Instead, signal the main app thread. For this simple case where xsan_node_main_spdk_thread_start
+        // is the one waiting, it can check this flag. Or, if everything is on one reactor, can call stop.
+        // For robustness, it's often better to send a message to the primary reactor to request shutdown.
+        // Here, we set a flag and the main app loop will see it.
+    }
+}
+// --- End of Async I/O Test ---
+
+
 static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
-    (void)arg1; // Unused argument
+    (void)arg1;
     xsan_error_t err = XSAN_OK;
     xsan_disk_manager_t *dm = NULL;
     xsan_volume_manager_t *vm = NULL;
@@ -36,33 +224,30 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
         goto app_stop_no_cleanup;
     }
 
-    // Initialize XSAN bdev subsystem (SPDK bdev interaction layer)
     if (xsan_bdev_subsystem_init() != XSAN_OK) {
         XSAN_LOG_FATAL("Failed to initialize XSAN bdev subsystem.");
         goto app_stop_no_cleanup;
     }
 
-    // Initialize XSAN Disk Manager
     err = xsan_disk_manager_init(&dm);
     if (err != XSAN_OK) {
         XSAN_LOG_FATAL("Failed to initialize XSAN Disk Manager: %s (code %d)", xsan_error_string(err), err);
         goto app_stop_bdev_fini_only;
     }
+    g_async_test_controller.dm = dm; // Give test context access to disk manager
 
-    // Initialize XSAN Volume Manager
     err = xsan_volume_manager_init(dm, &vm);
     if (err != XSAN_OK) {
         XSAN_LOG_FATAL("Failed to initialize XSAN Volume Manager: %s (code %d)", xsan_error_string(err), err);
         goto app_stop_dm_fini;
     }
+    g_async_test_controller.vm = vm; // Give test context access to volume manager
 
-    // Scan and register SPDK bdevs into the Disk Manager
     err = xsan_disk_manager_scan_and_register_bdevs(dm);
-    if (err != XSAN_OK && err != XSAN_ERROR_NOT_FOUND /* allow no bdevs found if it's a valid outcome */) {
+    if (err != XSAN_OK && err != XSAN_ERROR_NOT_FOUND ) {
         XSAN_LOG_ERROR("Error during bdev scan and registration: %s (code %d)", xsan_error_string(err), err);
     }
 
-    // List all XSAN disks
     xsan_disk_t **xsan_disks_list_ptr = NULL;
     int xsan_disk_count = 0;
     err = xsan_disk_manager_get_all_disks(dm, &xsan_disks_list_ptr, &xsan_disk_count);
@@ -70,9 +255,7 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
         XSAN_LOG_INFO("XSAN Disk Manager discovered %d disk(s):", xsan_disk_count);
         for (int i = 0; i < xsan_disk_count; ++i) {
             char xsan_disk_id_str[SPDK_UUID_STRING_LEN];
-            char bdev_uuid_str[SPDK_UUID_STRING_LEN];
             spdk_uuid_fmt_lower(xsan_disk_id_str, sizeof(xsan_disk_id_str), (struct spdk_uuid*)&xsan_disks_list_ptr[i]->id.data[0]);
-            spdk_uuid_fmt_lower(bdev_uuid_str, sizeof(bdev_uuid_str), (struct spdk_uuid*)&xsan_disks_list_ptr[i]->bdev_uuid.data[0]);
             XSAN_LOG_INFO("  Disk [%d]: XSAN_ID=%s, BDevName='%s', Size=%.2f GiB, Product='%s'",
                           i, xsan_disk_id_str, xsan_disks_list_ptr[i]->bdev_name,
                           (double)xsan_disks_list_ptr[i]->capacity_bytes / (1024.0*1024.0*1024.0),
@@ -82,13 +265,14 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
         XSAN_LOG_ERROR("Failed to get all XSAN disks: %s (code %d)", xsan_error_string(err), err);
     }
 
-    // --- Disk Group Test ---
     xsan_group_id_t test_group_id;
     memset(&test_group_id, 0, sizeof(xsan_group_id_t));
     bool group_created_flag = false;
+    xsan_disk_t *first_disk_for_group = NULL;
 
-    if (xsan_disk_count > 0 && xsan_disks_list_ptr) { // Ensure list_ptr is valid
-        const char *bdev_names_for_group[1] = { xsan_disks_list_ptr[0]->bdev_name };
+    if (xsan_disk_count > 0 && xsan_disks_list_ptr) {
+        first_disk_for_group = xsan_disks_list_ptr[0]; // Candidate for group
+        const char *bdev_names_for_group[1] = { first_disk_for_group->bdev_name };
         XSAN_LOG_INFO("Attempting to create disk group 'DG1' with bdev '%s'...", bdev_names_for_group[0]);
         err = xsan_disk_manager_disk_group_create(dm, "DG1", XSAN_DISK_GROUP_TYPE_PASSSTHROUGH,
                                                   bdev_names_for_group, 1, &test_group_id);
@@ -104,63 +288,27 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
         XSAN_LOG_WARN("Skipping disk group creation test: no XSAN disks available.");
     }
 
-    // --- Volume Management Test ---
     xsan_volume_id_t test_volume_id;
     memset(&test_volume_id, 0, sizeof(xsan_volume_id_t));
     bool volume_created_flag = false;
+    xsan_volume_t *created_volume_for_test = NULL;
 
     if (group_created_flag) {
-        uint64_t vol_size_mb = 128;
+        uint64_t vol_size_mb = (first_disk_for_group->capacity_bytes / (1024*1024) > 256) ? 128 : (first_disk_for_group->capacity_bytes / (1024*1024))/2; // Ensure vol size fits disk
+        if(vol_size_mb == 0) vol_size_mb = 1; // Min 1MB for test if disk is tiny
         uint64_t vol_size_bytes_test = vol_size_mb * 1024 * 1024;
         uint32_t vol_block_size_test = 4096;
-        XSAN_LOG_INFO("Attempting to create volume 'Vol1' (%.0f MiB, blocksize %uB) on group 'DG1'...",
-                      (double)vol_size_mb, vol_block_size_test);
+        if (vol_size_bytes_test < vol_block_size_test) vol_size_bytes_test = vol_block_size_test;
+
+
+        XSAN_LOG_INFO("Attempting to create volume 'Vol1' (%.0f MiB, blocksize %uB) on group 'DG1'...", (double)vol_size_mb, vol_block_size_test);
         err = xsan_volume_create(vm, "Vol1", vol_size_bytes_test, test_group_id, vol_block_size_test, false, &test_volume_id);
         if (err == XSAN_OK) {
             volume_created_flag = true;
+            created_volume_for_test = xsan_volume_get_by_id(vm, test_volume_id); // Get the created volume struct
             char vol_id_str[SPDK_UUID_STRING_LEN];
             spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_volume_id.data[0]);
             XSAN_LOG_INFO("Volume 'Vol1' created successfully, ID: %s", vol_id_str);
-
-            xsan_volume_t *fetched_vol_by_id = xsan_volume_get_by_id(vm, test_volume_id);
-            if (fetched_vol_by_id) {
-                 XSAN_LOG_INFO("Successfully fetched volume 'Vol1' by ID.");
-            } else {
-                 XSAN_LOG_ERROR("Failed to fetch volume 'Vol1' by ID.");
-            }
-            xsan_volume_t *fetched_vol_by_name = xsan_volume_get_by_name(vm, "Vol1");
-            if (fetched_vol_by_name) {
-                 XSAN_LOG_INFO("Successfully fetched volume 'Vol1' by name.");
-            } else {
-                 XSAN_LOG_ERROR("Failed to fetch volume 'Vol1' by name.");
-            }
-
-
-            // Test LBA mapping
-            xsan_disk_id_t mapped_disk_id;
-            uint64_t mapped_physical_lba;
-            uint64_t test_logical_lba_idx = 0;
-            err = xsan_volume_map_lba_to_physical(vm, test_volume_id, test_logical_lba_idx, &mapped_disk_id, &mapped_physical_lba);
-            if(err == XSAN_OK) {
-                char mapped_disk_id_str[SPDK_UUID_STRING_LEN];
-                spdk_uuid_fmt_lower(mapped_disk_id_str, sizeof(mapped_disk_id_str), (struct spdk_uuid*)&mapped_disk_id.data[0]);
-                XSAN_LOG_INFO("Volume 'Vol1' LBA_idx %lu maps to XSAN Disk ID: %s, Physical LBA_idx: %lu",
-                              test_logical_lba_idx, mapped_disk_id_str, mapped_physical_lba);
-            } else {
-                 XSAN_LOG_ERROR("Failed to map LBA %lu for 'Vol1': %s (code %d)", test_logical_lba_idx, xsan_error_string(err), err);
-            }
-            // Test another LBA
-            test_logical_lba_idx = (vol_size_bytes_test / vol_block_size_test) - 1; // Last block
-             err = xsan_volume_map_lba_to_physical(vm, test_volume_id, test_logical_lba_idx, &mapped_disk_id, &mapped_physical_lba);
-            if(err == XSAN_OK) {
-                char mapped_disk_id_str[SPDK_UUID_STRING_LEN];
-                spdk_uuid_fmt_lower(mapped_disk_id_str, sizeof(mapped_disk_id_str), (struct spdk_uuid*)&mapped_disk_id.data[0]);
-                XSAN_LOG_INFO("Volume 'Vol1' LBA_idx %lu maps to XSAN Disk ID: %s, Physical LBA_idx: %lu",
-                              test_logical_lba_idx, mapped_disk_id_str, mapped_physical_lba);
-            } else {
-                 XSAN_LOG_ERROR("Failed to map LBA %lu for 'Vol1': %s (code %d)", test_logical_lba_idx, xsan_error_string(err), err);
-            }
-
         } else {
             XSAN_LOG_ERROR("Failed to create volume 'Vol1': %s (code %d)", xsan_error_string(err), err);
         }
@@ -168,65 +316,30 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
         XSAN_LOG_WARN("Skipping volume creation test: disk group 'DG1' was not created.");
     }
 
-    // List all volumes
-    xsan_volume_t **volumes_list_ptr = NULL;
-    int volume_count = 0;
-    if (xsan_volume_list_all(vm, &volumes_list_ptr, &volume_count) == XSAN_OK) {
-        XSAN_LOG_INFO("Found %d volume(s) via Volume Manager:", volume_count);
-        for(int i=0; i<volume_count; ++i) {
-            char v_id_str[SPDK_UUID_STRING_LEN];
-            spdk_uuid_fmt_lower(v_id_str, sizeof(v_id_str), (struct spdk_uuid*)&volumes_list_ptr[i]->id.data[0]);
-            XSAN_LOG_INFO("  Vol [%d]: Name='%s', ID=%s, Size=%.2f GiB, BlockSize=%uB", i,
-                          volumes_list_ptr[i]->name, v_id_str,
-                          (double)volumes_list_ptr[i]->size_bytes / (1024.0*1024.0*1024.0),
-                          volumes_list_ptr[i]->block_size_bytes);
-        }
-        xsan_volume_manager_free_volume_pointer_list(volumes_list_ptr);
-    }
-
-    // --- BDEV R/W Test (Maintained) ---
-    if (xsan_disk_count > 0 && xsan_disks_list_ptr) {
-        xsan_disk_t* rw_test_disk = NULL;
-        for(int i=0; i<xsan_disk_count; ++i) {
-             if(xsan_disks_list_ptr[i] && strstr(xsan_disks_list_ptr[i]->bdev_name, "Malloc") != NULL) {
-                 rw_test_disk = xsan_disks_list_ptr[i];
-                 break;
-             }
-        }
-        if (!rw_test_disk && xsan_disk_count > 0 && xsan_disks_list_ptr) rw_test_disk = xsan_disks_list_ptr[0];
-
-        if (rw_test_disk && rw_test_disk->num_blocks > 0 && rw_test_disk->block_size_bytes > 0) {
-            XSAN_LOG_INFO("--- Performing R/W Test on XSAN disk (bdev: '%s') ---", rw_test_disk->bdev_name);
-            uint32_t blk_size_rw_test = rw_test_disk->block_size_bytes;
-            size_t bdev_align_rw_test = xsan_bdev_get_buf_align(rw_test_disk->bdev_name);
-            void *write_buf_rw = xsan_bdev_dma_malloc(blk_size_rw_test, bdev_align_rw_test);
-            void *read_buf_rw = xsan_bdev_dma_malloc(blk_size_rw_test, bdev_align_rw_test);
-            if (write_buf_rw && read_buf_rw) {
-                snprintf((char*)write_buf_rw, blk_size_rw_test, "XSAN R/W Test on %s!", rw_test_disk->bdev_name);
-                for(size_t k=strlen((char*)write_buf_rw); k<blk_size_rw_test; ++k) ((char*)write_buf_rw)[k] = (char)((k % 255) + 1);
-                memset(read_buf_rw, 0xAA, blk_size_rw_test);
-
-                err = xsan_bdev_write_sync(rw_test_disk->bdev_name, 0, 1, write_buf_rw, blk_size_rw_test, false);
-                if (err == XSAN_OK) {
-                    XSAN_LOG_DEBUG("Write to '%s' block 0 successful.", rw_test_disk->bdev_name);
-                    err = xsan_bdev_read_sync(rw_test_disk->bdev_name, 0, 1, read_buf_rw, blk_size_rw_test, false);
-                    if (err == XSAN_OK) {
-                        XSAN_LOG_DEBUG("Read from '%s' block 0 successful.", rw_test_disk->bdev_name);
-                        if (memcmp(write_buf_rw, read_buf_rw, blk_size_rw_test) == 0) {
-                            XSAN_LOG_INFO("SUCCESS: R/W data verification for '%s' passed!", rw_test_disk->bdev_name);
-                        } else { XSAN_LOG_ERROR("FAILURE: R/W data verification for '%s' FAILED!", rw_test_disk->bdev_name); }
-                    } else { XSAN_LOG_ERROR("Read from '%s' failed: %s (code %d)", rw_test_disk->bdev_name, xsan_error_string(err), err); }
-                } else { XSAN_LOG_ERROR("Write to '%s' failed: %s (code %d)", rw_test_disk->bdev_name, xsan_error_string(err), err); }
-            } else { XSAN_LOG_ERROR("Failed to allocate DMA buffers for R/W test on '%s'.", rw_test_disk->bdev_name); }
-            if(write_buf_rw) xsan_bdev_dma_free(write_buf_rw);
-            if(read_buf_rw) xsan_bdev_dma_free(read_buf_rw);
-            XSAN_LOG_INFO("--- R/W Test on '%s' finished ---", rw_test_disk->bdev_name);
-        }
-    }
     if (xsan_disks_list_ptr) {
         xsan_disk_manager_free_disk_pointer_list(xsan_disks_list_ptr);
         xsan_disks_list_ptr = NULL;
     }
+
+    // --- Async I/O Test ---
+    if (volume_created_flag && created_volume_for_test && first_disk_for_group) {
+        g_async_test_controller.all_tests_finished_signal = false;
+        _start_async_io_test_on_volume(&g_async_test_controller, created_volume_for_test);
+        // The rest of the cleanup and app_stop will be triggered by the async callbacks
+        // via _finalize_and_stop_app_if_all_done setting all_tests_finished_signal.
+        // This SPDK thread needs to keep polling for completions.
+        // If _start_async_io_test_on_volume itself failed to submit, it might have already set the signal.
+        while(!g_async_test_controller.all_tests_finished_signal) {
+            // This is a busy wait if this thread isn't a reactor.
+            // Assuming this main app function is on a reactor, completions will be polled.
+            // If not, we must explicitly poll the thread this IO was submitted on.
+            // For simplicity, we assume this thread is the one that will poll.
+            // In a multi-reactor setup, IOs are submitted to a specific reactor.
+            spdk_thread_poll(spdk_get_thread(), 0, 0); // Poll current thread for completions
+        }
+        // Now that async test is done (or failed early), proceed to cleanup the test volume/group
+    }
+
 
     // --- Cleanup Tests ---
     if (volume_created_flag) {
@@ -252,9 +365,44 @@ app_stop_dm_fini:
 app_stop_bdev_fini_only:
     xsan_bdev_subsystem_fini();
 app_stop_no_cleanup:
-    // Finalize Volume Manager if it was initialized
     if (vm) xsan_volume_manager_fini(&vm);
 
     XSAN_LOG_INFO("XSAN SPDK application thread work complete or aborted. Requesting application stop.");
-    xsan_spdk_manager_request_app_stop(); // Signal SPDK framework to shut down
+    xsan_spdk_manager_request_app_stop();
+}
+
+// main function remains largely the same
+int main(int argc, char **argv) {
+    xsan_log_config_t log_cfg = xsan_log_default_config();
+    log_cfg.level = XSAN_LOG_LEVEL_DEBUG;
+    xsan_log_init(&log_cfg);
+
+    XSAN_LOG_INFO("XSAN Node starting (main function)...");
+
+    const char *spdk_json_conf_file = NULL;
+    if (argc > 1) {
+        spdk_json_conf_file = argv[1];
+        XSAN_LOG_INFO("Using SPDK JSON configuration file: %s", spdk_json_conf_file);
+    } else {
+        XSAN_LOG_WARN("No SPDK JSON configuration file provided via command line arguments.");
+        XSAN_LOG_WARN("For testing with Malloc bdevs, create a JSON config (e.g., bdev_malloc.json) and pass it.");
+        XSAN_LOG_WARN("Example JSON for Malloc bdev: {\"subsystems\":[{\"subsystem\":\"bdev\",\"config\":[{\"method\":\"bdev_malloc_create\",\"params\":{\"name\":\"Malloc0\",\"num_blocks\":131072,\"block_size\":4096}}]}]}");
+    }
+
+    xsan_error_t err = xsan_spdk_manager_opts_init("xsan_node_main", spdk_json_conf_file, "0x1", false, NULL);
+    if (err != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to initialize SPDK manager options: %s (code %d)", xsan_error_string(err), err);
+        xsan_log_shutdown();
+        return EXIT_FAILURE;
+    }
+
+    err = xsan_spdk_manager_start_app(xsan_node_main_spdk_thread_start, NULL);
+    if (err != XSAN_OK) {
+        XSAN_LOG_FATAL("xsan_spdk_manager_start_app returned with error: %s (code %d)", xsan_error_string(err), err);
+    }
+
+    xsan_spdk_manager_app_fini();
+    XSAN_LOG_INFO("XSAN Node has shut down.");
+    xsan_log_shutdown();
+    return (err == XSAN_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -41,7 +41,8 @@ target_include_directories(xsan_storage PUBLIC
 target_link_libraries(xsan_storage PUBLIC # Use PUBLIC to propagate interface includes from dependencies
     xsan_utils      # For logging, memory, string utils
     xsan_common     # For error types, list, hashtable, ringbuffer, (spdk/uuid.h via xsan_types.h)
-    xsan_bdev       # disk_manager depends on xsan_bdev
+    xsan_bdev       # disk_manager and volume_manager (via xsan_io) depend on xsan_bdev
+    xsan_io         # volume_manager depends on xsan_io for async operations
     # xsan_network  # Only if storage directly does network ops, unlikely for disk/vol managers
                     # Dependencies like LEVELDB_LIB and UUID_LIB should be conditional
                     # or found via find_package by the modules that actually need them.

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5,7 +5,9 @@
 #include "xsan_string_utils.h" // For xsan_strcpy_safe
 #include "xsan_log.h"      // For XSAN_LOG_INFO, XSAN_LOG_ERROR, etc.
 
-#include "spdk/uuid.h"     // For spdk_uuid_generate, spdk_uuid_compare
+#include "spdk/uuid.h"     // For spdk_uuid_generate, spdk_uuid_compare, spdk_uuid_is_null, spdk_uuid_get_string
+#include "spdk/bdev.h"     // For spdk_bdev_open_ext, spdk_bdev_close
+#include "spdk/thread.h"   // For spdk_get_thread
 #include <pthread.h>       // For pthread_mutex_t
 
 // The internal structure for the disk manager
@@ -17,15 +19,21 @@ struct xsan_disk_manager {
 };
 
 // Global disk manager instance (singleton pattern)
-// This simplifies access but means init/fini must be managed carefully.
 static xsan_disk_manager_t *g_xsan_disk_manager_instance = NULL;
 
 // Destructor callback for xsan_disk_t elements in xsan_list
 static void _xsan_internal_disk_destroy_cb(void *disk_data) {
     if (disk_data) {
         xsan_disk_t *disk = (xsan_disk_t *)disk_data;
-        XSAN_LOG_DEBUG("Disk Manager: Destroying xsan_disk (bdev: %s)", disk->bdev_name);
-        // Any specific cleanup for xsan_disk_t itself, if not just memory.
+        char xsan_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(xsan_id_str, sizeof(xsan_id_str), (struct spdk_uuid*)&disk->id.data[0]);
+        XSAN_LOG_DEBUG("Disk Manager: Destroying xsan_disk (bdev: %s, XSAN_ID: %s)", disk->bdev_name, xsan_id_str);
+
+        if (disk->bdev_descriptor) {
+            spdk_bdev_close(disk->bdev_descriptor);
+            disk->bdev_descriptor = NULL;
+            XSAN_LOG_DEBUG("Closed SPDK bdev descriptor for bdev: %s", disk->bdev_name);
+        }
         XSAN_FREE(disk);
     }
 }
@@ -34,9 +42,9 @@ static void _xsan_internal_disk_destroy_cb(void *disk_data) {
 static void _xsan_internal_disk_group_destroy_cb(void *group_data) {
     if (group_data) {
         xsan_disk_group_t *group = (xsan_disk_group_t *)group_data;
-        XSAN_LOG_DEBUG("Disk Manager: Destroying xsan_disk_group (name: %s)", group->name);
-        // Disks referenced by disk_ids are managed in the main 'managed_disks' list.
-        // No need to free them here, just the group structure itself.
+        char group_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(group_id_str, sizeof(group_id_str), (struct spdk_uuid*)&group->id.data[0]);
+        XSAN_LOG_DEBUG("Disk Manager: Destroying xsan_disk_group (Name: '%s', ID: %s)", group->name, group_id_str);
         XSAN_FREE(group);
     }
 }
@@ -44,16 +52,11 @@ static void _xsan_internal_disk_group_destroy_cb(void *group_data) {
 xsan_error_t xsan_disk_manager_init(xsan_disk_manager_t **dm_instance_out) {
     if (g_xsan_disk_manager_instance != NULL) {
         XSAN_LOG_WARN("XSAN Disk Manager already initialized.");
-        if (dm_instance_out) {
-            *dm_instance_out = g_xsan_disk_manager_instance;
-        }
-        // Consider if returning OK or an "already initialized" error is better.
-        // For now, let's treat it as success to get the instance.
+        if (dm_instance_out) *dm_instance_out = g_xsan_disk_manager_instance;
         return XSAN_OK;
     }
 
     XSAN_LOG_INFO("Initializing XSAN Disk Manager...");
-
     xsan_disk_manager_t *dm = (xsan_disk_manager_t *)XSAN_MALLOC(sizeof(xsan_disk_manager_t));
     if (!dm) {
         XSAN_LOG_ERROR("Failed to allocate memory for XSAN Disk Manager structure.");
@@ -84,7 +87,7 @@ xsan_error_t xsan_disk_manager_init(xsan_disk_manager_t **dm_instance_out) {
         xsan_list_destroy(dm->managed_disks);
         XSAN_FREE(dm);
         if (dm_instance_out) *dm_instance_out = NULL;
-        return XSAN_ERROR_SYSTEM; // Or a more specific mutex error
+        return XSAN_ERROR_SYSTEM;
     }
 
     dm->initialized = true;
@@ -99,27 +102,24 @@ xsan_error_t xsan_disk_manager_init(xsan_disk_manager_t **dm_instance_out) {
 
 void xsan_disk_manager_fini(xsan_disk_manager_t **dm_ptr) {
     xsan_disk_manager_t *dm_to_fini = NULL;
-
-    if (dm_ptr && *dm_ptr) { // User passed a pointer to their variable
+    if (dm_ptr && *dm_ptr) {
         dm_to_fini = *dm_ptr;
-    } else if (g_xsan_disk_manager_instance) { // User passed NULL, try global
+    } else if (g_xsan_disk_manager_instance) {
         dm_to_fini = g_xsan_disk_manager_instance;
     }
 
     if (!dm_to_fini || !dm_to_fini->initialized) {
         XSAN_LOG_INFO("XSAN Disk Manager already finalized or was not initialized.");
-        if (dm_ptr) *dm_ptr = NULL; // Ensure caller's pointer is NULL if they passed one
-        g_xsan_disk_manager_instance = NULL; // Ensure global is NULL
+        if (dm_ptr) *dm_ptr = NULL;
+        g_xsan_disk_manager_instance = NULL;
         return;
     }
 
     XSAN_LOG_INFO("Finalizing XSAN Disk Manager...");
     pthread_mutex_lock(&dm_to_fini->lock);
 
-    // xsan_list_destroy calls the destructor for each element, which frees xsan_disk_t and xsan_disk_group_t
     xsan_list_destroy(dm_to_fini->managed_disk_groups);
     dm_to_fini->managed_disk_groups = NULL;
-
     xsan_list_destroy(dm_to_fini->managed_disks);
     dm_to_fini->managed_disks = NULL;
 
@@ -137,22 +137,18 @@ void xsan_disk_manager_fini(xsan_disk_manager_t **dm_ptr) {
     XSAN_LOG_INFO("XSAN Disk Manager finalized.");
 }
 
-// Implementation for xsan_disk_manager_scan_and_register_bdevs
 xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) {
     if (!dm || !dm->initialized) {
         XSAN_LOG_ERROR("Disk manager not initialized or NULL when trying to scan bdevs.");
-        return XSAN_ERROR_INVALID_PARAM; // Or a more specific "not initialized" error
+        return XSAN_ERROR_INVALID_PARAM;
     }
-
-    // This function MUST be called from an SPDK thread.
     if (spdk_get_thread() == NULL) {
         XSAN_LOG_ERROR("xsan_disk_manager_scan_and_register_bdevs must be called from an SPDK thread.");
         return XSAN_ERROR_THREAD_CONTEXT;
     }
 
     XSAN_LOG_INFO("Scanning for SPDK bdevs to register/update in XSAN Disk Manager...");
-
-    xsan_bdev_info_t *bdev_info_list = NULL; // This will be an array of xsan_bdev_info_t structs
+    xsan_bdev_info_t *bdev_info_list = NULL;
     int bdev_count = 0;
     xsan_error_t err = xsan_bdev_list_get_all(&bdev_info_list, &bdev_count);
 
@@ -160,24 +156,20 @@ xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) 
         XSAN_LOG_ERROR("Failed to get list of SPDK bdevs from xsan_bdev module: %s (code %d)", xsan_error_string(err), err);
         return err;
     }
-
     if (bdev_count == 0) {
         XSAN_LOG_INFO("No SPDK bdevs found by xsan_bdev module.");
-        // No need to free bdev_info_list as it would be NULL.
         return XSAN_OK;
     }
 
     XSAN_LOG_INFO("Found %d SPDK bdev(s). Processing for registration/update...", bdev_count);
     int new_registered_count = 0;
     int updated_count = 0;
-    int skipped_count = 0; // For bdevs that are perhaps not suitable
 
     pthread_mutex_lock(&dm->lock);
+    xsan_error_t overall_err_status = XSAN_OK; // Track if any error occurs during loop
 
     for (int i = 0; i < bdev_count; ++i) {
-        xsan_bdev_info_t *current_bdev_info = &bdev_info_list[i]; // Direct struct from the array
-
-        // Try to find if this bdev (by name) is already managed as an xsan_disk_t
+        xsan_bdev_info_t *current_bdev_info = &bdev_info_list[i];
         xsan_disk_t *existing_disk = NULL;
         xsan_list_node_t *list_node;
         XSAN_LIST_FOREACH(dm->managed_disks, list_node) {
@@ -189,11 +181,7 @@ xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) 
         }
 
         if (existing_disk) {
-            // Bdev already exists as an xsan_disk. Update its properties if necessary.
-            // For now, we'll just log and update basic info. More sophisticated update logic
-            // (e.g., handling state changes if SPDK could report them here) can be added.
             XSAN_LOG_DEBUG("Updating existing XSAN disk for bdev '%s'.", current_bdev_info->name);
-            // Update fields that might change or need refreshing
             memcpy(&existing_disk->bdev_uuid, &current_bdev_info->uuid, sizeof(xsan_uuid_t));
             existing_disk->capacity_bytes = current_bdev_info->capacity_bytes;
             existing_disk->block_size_bytes = current_bdev_info->block_size;
@@ -202,7 +190,6 @@ xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) 
             existing_disk->is_rotational = current_bdev_info->is_rotational;
             existing_disk->optimal_io_boundary_blocks = current_bdev_info->optimal_io_boundary;
             existing_disk->has_write_cache = current_bdev_info->has_write_cache;
-            // Re-infer type (simplified)
             if (strstr(current_bdev_info->name, "Nvme") != NULL || strstr(current_bdev_info->product_name, "NVMe") !=NULL) {
                 existing_disk->type = XSAN_STORAGE_DISK_TYPE_NVME_SSD;
             } else if (current_bdev_info->is_rotational) {
@@ -210,34 +197,33 @@ xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) 
             } else {
                 existing_disk->type = XSAN_STORAGE_DISK_TYPE_SATA_SSD;
             }
-            // Assume state remains ONLINE unless SPDK provides other info (not directly from bdev_info here)
-            // existing_disk->state = XSAN_STORAGE_STATE_ONLINE;
+            if (!existing_disk->bdev_descriptor) { // Attempt to open if not already open
+                int rc_open = spdk_bdev_open_ext(existing_disk->bdev_name, true, NULL, NULL, &existing_disk->bdev_descriptor);
+                if (rc_open != 0) {
+                    XSAN_LOG_ERROR("Failed to re-open bdev descriptor for '%s': %s", existing_disk->bdev_name, spdk_strerror(-rc_open));
+                    existing_disk->state = XSAN_STORAGE_STATE_FAILED;
+                } else {
+                     existing_disk->state = XSAN_STORAGE_STATE_ONLINE; // Assume online if successfully opened/re-opened
+                }
+            } // else: descriptor already open, assume state is managed elsewhere or remains ONLINE
             updated_count++;
         } else {
-            // Bdev not found, register as a new xsan_disk_t
             xsan_disk_t *new_disk = (xsan_disk_t *)XSAN_MALLOC(sizeof(xsan_disk_t));
             if (!new_disk) {
-                XSAN_LOG_ERROR("Failed to allocate memory for new xsan_disk_t for bdev '%s'.", current_bdev_info->name);
-                err = XSAN_ERROR_OUT_OF_MEMORY; // Mark error, but try to continue for other bdevs
-                continue;
+                XSAN_LOG_ERROR("Failed to MALLOC xsan_disk_t for bdev '%s'.", current_bdev_info->name);
+                overall_err_status = XSAN_ERROR_OUT_OF_MEMORY; continue;
             }
             memset(new_disk, 0, sizeof(xsan_disk_t));
-
-            // Generate a new XSAN unique ID for this disk
             spdk_uuid_generate((struct spdk_uuid *)&new_disk->id.data[0]);
-
             xsan_strcpy_safe(new_disk->bdev_name, current_bdev_info->name, XSAN_MAX_NAME_LEN);
             memcpy(&new_disk->bdev_uuid, &current_bdev_info->uuid, sizeof(xsan_uuid_t));
-
             new_disk->capacity_bytes = current_bdev_info->capacity_bytes;
             new_disk->block_size_bytes = current_bdev_info->block_size;
             new_disk->num_blocks = current_bdev_info->num_blocks;
             xsan_strcpy_safe(new_disk->product_name, current_bdev_info->product_name, XSAN_MAX_NAME_LEN);
-
             new_disk->is_rotational = current_bdev_info->is_rotational;
             new_disk->optimal_io_boundary_blocks = current_bdev_info->optimal_io_boundary;
             new_disk->has_write_cache = current_bdev_info->has_write_cache;
-
             if (strstr(current_bdev_info->name, "Nvme") != NULL || strstr(current_bdev_info->product_name, "NVMe") !=NULL) {
                 new_disk->type = XSAN_STORAGE_DISK_TYPE_NVME_SSD;
             } else if (current_bdev_info->is_rotational) {
@@ -245,33 +231,36 @@ xsan_error_t xsan_disk_manager_scan_and_register_bdevs(xsan_disk_manager_t *dm) 
             } else {
                 new_disk->type = XSAN_STORAGE_DISK_TYPE_SATA_SSD;
             }
-            new_disk->state = XSAN_STORAGE_STATE_ONLINE; // Initial state
+
+            int rc_open = spdk_bdev_open_ext(new_disk->bdev_name, true, NULL, NULL, &new_disk->bdev_descriptor);
+            if (rc_open != 0) {
+                XSAN_LOG_ERROR("Failed to open bdev '%s' for XSAN disk: %s. Marked FAILED.", new_disk->bdev_name, spdk_strerror(-rc_open));
+                new_disk->state = XSAN_STORAGE_STATE_FAILED;
+                new_disk->bdev_descriptor = NULL;
+            } else {
+                new_disk->state = XSAN_STORAGE_STATE_ONLINE;
+            }
+            memset(&new_disk->assigned_to_group_id, 0, sizeof(xsan_group_id_t));
 
             if (xsan_list_append(dm->managed_disks, new_disk) == NULL) {
                 XSAN_LOG_ERROR("Failed to append new disk (bdev '%s') to managed list.", new_disk->bdev_name);
-                _xsan_internal_disk_destroy_cb(new_disk); // Free the allocated disk if append fails
-                err = XSAN_ERROR_OUT_OF_MEMORY;
+                if(new_disk->bdev_descriptor) spdk_bdev_close(new_disk->bdev_descriptor);
+                XSAN_FREE(new_disk); // Use XSAN_FREE since _xsan_internal_disk_destroy_cb is for list removal
+                overall_err_status = XSAN_ERROR_OUT_OF_MEMORY;
             } else {
                 char xsan_id_str[SPDK_UUID_STRING_LEN];
                 spdk_uuid_fmt_lower(xsan_id_str, sizeof(xsan_id_str), (struct spdk_uuid*)&new_disk->id.data[0]);
-                XSAN_LOG_INFO("Registered new XSAN disk: Name='%s', XSAN_ID=%s, Type=%d, Size=%.2f GiB",
-                              new_disk->bdev_name, xsan_id_str, new_disk->type,
+                XSAN_LOG_INFO("Registered new XSAN disk: BDevName='%s', XSAN_ID=%s, Type=%d, State=%d, Size=%.2f GiB",
+                              new_disk->bdev_name, xsan_id_str, new_disk->type, new_disk->state,
                               (double)new_disk->capacity_bytes / (1024.0*1024.0*1024.0));
                 new_registered_count++;
             }
         }
     }
-
     pthread_mutex_unlock(&dm->lock);
-
-    // Free the bdev_info_list obtained from xsan_bdev_list_get_all()
-    // The list itself is a single allocation containing all xsan_bdev_info_t structs.
     xsan_bdev_list_free(bdev_info_list, bdev_count);
-
-    XSAN_LOG_INFO("SPDK bdev scan and registration complete. New: %d, Updated: %d, Skipped/No-change: %d.",
-                  new_registered_count, updated_count, bdev_count - new_registered_count - updated_count);
-
-    return err; // Returns XSAN_OK if all operations were successful, or the last error encountered.
+    XSAN_LOG_INFO("SPDK bdev scan and registration complete. New: %d, Updated: %d.", new_registered_count, updated_count);
+    return overall_err_status;
 }
 
 xsan_error_t xsan_disk_manager_get_all_disks(xsan_disk_manager_t *dm, xsan_disk_t ***disks_array_out, int *count_out) {
@@ -300,13 +289,13 @@ xsan_error_t xsan_disk_manager_get_all_disks(xsan_disk_manager_t *dm, xsan_disk_
     int i = 0;
     xsan_list_node_t *node;
     XSAN_LIST_FOREACH(dm->managed_disks, node) {
-        if (i < (int)num_disks) { // Defensive check
+        if (i < (int)num_disks) {
             (*disks_array_out)[i++] = (xsan_disk_t *)xsan_list_node_get_value(node);
         } else {
-            break; // Should not happen
+            break;
         }
     }
-    *count_out = i; // Actual count copied
+    *count_out = i;
     pthread_mutex_unlock(&dm->lock);
     return XSAN_OK;
 }
@@ -360,76 +349,84 @@ xsan_error_t xsan_disk_manager_disk_group_create(xsan_disk_manager_t *dm,
     if (!dm || !dm->initialized || !group_name || !bdev_names_list || num_bdevs <= 0 || num_bdevs > XSAN_MAX_DISKS_PER_GROUP) {
         return XSAN_ERROR_INVALID_PARAM;
     }
-    if (spdk_get_thread() == NULL) {
-        XSAN_LOG_ERROR("xsan_disk_manager_disk_group_create must be called from an SPDK thread (for potential future SPDK interactions).");
-        // While this specific impl might not call SPDK, related functions often do.
-        // return XSAN_ERROR_THREAD_CONTEXT; // Relaxing this for now as it's primarily list manipulation
-    }
+    // if (spdk_get_thread() == NULL) {
+    //     XSAN_LOG_ERROR("xsan_disk_manager_disk_group_create must be called from an SPDK thread.");
+    //     return XSAN_ERROR_THREAD_CONTEXT;
+    // } // Relaxed for now as it's mostly list manipulation
 
     pthread_mutex_lock(&dm->lock);
     xsan_error_t err = XSAN_OK;
 
-    // Check if group name already exists
-    if (xsan_disk_manager_find_disk_group_by_name(dm, group_name) != NULL) {
-        XSAN_LOG_WARN("Disk group with name '%s' already exists.", group_name);
-        pthread_mutex_unlock(&dm->lock);
-        return XSAN_ERROR_ALREADY_EXISTS;
+    xsan_list_node_t *iter_node_group;
+    XSAN_LIST_FOREACH(dm->managed_disk_groups, iter_node_group) {
+        xsan_disk_group_t *dg_iter = (xsan_disk_group_t*)xsan_list_node_get_value(iter_node_group);
+        if (strncmp(dg_iter->name, group_name, XSAN_MAX_NAME_LEN) == 0) {
+            XSAN_LOG_WARN("Disk group with name '%s' already exists.", group_name);
+            pthread_mutex_unlock(&dm->lock);
+            return XSAN_ERROR_ALREADY_EXISTS;
+        }
     }
 
-    xsan_disk_t *member_disks[XSAN_MAX_DISKS_PER_GROUP];
-    uint64_t total_capacity = 0;
+
+    xsan_disk_t *member_disks_ptrs[XSAN_MAX_DISKS_PER_GROUP]; // Store pointers to check later
+    uint64_t calculated_total_capacity = 0;
 
     for (int i = 0; i < num_bdevs; ++i) {
-        xsan_disk_t *disk = xsan_disk_manager_find_disk_by_bdev_name(dm, bdev_names_list[i]);
+        xsan_disk_t *disk = NULL; // Find disk without holding lock for long
+        xsan_list_node_t *disk_node;
+        XSAN_LIST_FOREACH(dm->managed_disks, disk_node) {
+            xsan_disk_t *d_iter = (xsan_disk_t *)xsan_list_node_get_value(disk_node);
+            if (strncmp(d_iter->bdev_name, bdev_names_list[i], XSAN_MAX_NAME_LEN) == 0) {
+                disk = d_iter;
+                break;
+            }
+        }
+
         if (!disk) {
             XSAN_LOG_ERROR("Disk with bdev name '%s' not found for group '%s'.", bdev_names_list[i], group_name);
             err = XSAN_ERROR_NOT_FOUND;
-            goto cleanup_unlock;
+            goto create_group_cleanup_unlock;
         }
         if (!spdk_uuid_is_null((struct spdk_uuid*)&disk->assigned_to_group_id.data[0])) {
-            char group_uuid_str[SPDK_UUID_STRING_LEN];
-            spdk_uuid_fmt_lower(group_uuid_str, sizeof(group_uuid_str), (struct spdk_uuid*)&disk->assigned_to_group_id.data[0]);
+            char assigned_group_uuid_str[SPDK_UUID_STRING_LEN];
+            spdk_uuid_fmt_lower(assigned_group_uuid_str, sizeof(assigned_group_uuid_str), (struct spdk_uuid*)&disk->assigned_to_group_id.data[0]);
             XSAN_LOG_ERROR("Disk '%s' (bdev: %s) is already assigned to group %s.",
-                           spdk_uuid_get_string((struct spdk_uuid*)&disk->id.data[0]), disk->bdev_name, group_uuid_str);
-            err = XSAN_ERROR_RESOURCE_BUSY; // Disk already in use
-            goto cleanup_unlock;
+                           spdk_uuid_get_string((struct spdk_uuid*)&disk->id.data[0]), disk->bdev_name, assigned_group_uuid_str);
+            err = XSAN_ERROR_RESOURCE_BUSY;
+            goto create_group_cleanup_unlock;
         }
-        member_disks[i] = disk;
-        total_capacity += disk->capacity_bytes;
+        member_disks_ptrs[i] = disk;
+        calculated_total_capacity += disk->capacity_bytes;
     }
 
     xsan_disk_group_t *new_group = (xsan_disk_group_t *)XSAN_MALLOC(sizeof(xsan_disk_group_t));
     if (!new_group) {
         err = XSAN_ERROR_OUT_OF_MEMORY;
-        goto cleanup_unlock;
+        goto create_group_cleanup_unlock;
     }
     memset(new_group, 0, sizeof(xsan_disk_group_t));
 
     spdk_uuid_generate((struct spdk_uuid *)&new_group->id.data[0]);
     xsan_strcpy_safe(new_group->name, group_name, XSAN_MAX_NAME_LEN);
     new_group->type = group_type;
-    new_group->state = XSAN_STORAGE_STATE_ONLINE; // Initial state
-    new_group->disk_count = num_bdevs;
-    new_group->total_capacity_bytes = total_capacity;
-    // For PASSSTHROUGH/JBOD, usable might be same as total initially.
-    // RAID would reduce this.
-    new_group->usable_capacity_bytes = total_capacity;
+    new_group->state = XSAN_STORAGE_STATE_ONLINE;
+    new_group->disk_count = (uint32_t)num_bdevs;
+    new_group->total_capacity_bytes = calculated_total_capacity;
+    new_group->usable_capacity_bytes = calculated_total_capacity; // Simplification for PASSSTHROUGH/JBOD
 
     for (int i = 0; i < num_bdevs; ++i) {
-        memcpy(&new_group->disk_ids[i], &member_disks[i]->id, sizeof(xsan_disk_id_t));
-        // Mark disk as assigned to this group
-        memcpy(&member_disks[i]->assigned_to_group_id, &new_group->id, sizeof(xsan_group_id_t));
+        memcpy(&new_group->disk_ids[i], &member_disks_ptrs[i]->id, sizeof(xsan_disk_id_t));
+        memcpy(&member_disks_ptrs[i]->assigned_to_group_id, &new_group->id, sizeof(xsan_group_id_t));
     }
 
     if (xsan_list_append(dm->managed_disk_groups, new_group) == NULL) {
         XSAN_LOG_ERROR("Failed to append new disk group '%s' to managed list.", new_group->name);
-        // Revert assigned_to_group_id for disks
-        for (int i = 0; i < num_bdevs; ++i) {
-             memset(&member_disks[i]->assigned_to_group_id, 0, sizeof(xsan_group_id_t));
+        for (int i = 0; i < num_bdevs; ++i) { // Revert assignment
+             if(member_disks_ptrs[i]) memset(&member_disks_ptrs[i]->assigned_to_group_id, 0, sizeof(xsan_group_id_t));
         }
-        _xsan_internal_disk_group_destroy_cb(new_group); // Frees new_group itself
+        XSAN_FREE(new_group); // _xsan_internal_disk_group_destroy_cb is not called by list
         err = XSAN_ERROR_OUT_OF_MEMORY;
-        goto cleanup_unlock;
+        goto create_group_cleanup_unlock;
     }
 
     if (group_id_out) {
@@ -438,10 +435,10 @@ xsan_error_t xsan_disk_manager_disk_group_create(xsan_disk_manager_t *dm,
 
     char group_uuid_str_log[SPDK_UUID_STRING_LEN];
     spdk_uuid_fmt_lower(group_uuid_str_log, sizeof(group_uuid_str_log), (struct spdk_uuid*)&new_group->id.data[0]);
-    XSAN_LOG_INFO("Disk group '%s' (ID: %s, Type: %d) created successfully with %d disk(s).",
+    XSAN_LOG_INFO("Disk group '%s' (ID: %s, Type: %d) created successfully with %u disk(s).",
                   new_group->name, group_uuid_str_log, new_group->type, new_group->disk_count);
 
-cleanup_unlock:
+create_group_cleanup_unlock:
     pthread_mutex_unlock(&dm->lock);
     return err;
 }
@@ -456,40 +453,50 @@ xsan_error_t xsan_disk_manager_disk_group_delete(xsan_disk_manager_t *dm, xsan_g
 
     pthread_mutex_lock(&dm->lock);
     xsan_error_t err = XSAN_ERROR_NOT_FOUND;
-    xsan_list_node_t *list_node = xsan_list_get_head(dm->managed_disk_groups);
+    xsan_list_node_t *list_node_group = xsan_list_get_head(dm->managed_disk_groups);
     xsan_disk_group_t *group_to_delete = NULL;
 
-    while(list_node != NULL) {
-        xsan_disk_group_t *current_group = (xsan_disk_group_t *)xsan_list_node_get_value(list_node);
+    while(list_node_group != NULL) {
+        xsan_disk_group_t *current_group = (xsan_disk_group_t *)xsan_list_node_get_value(list_node_group);
         if (spdk_uuid_compare((struct spdk_uuid*)&current_group->id.data[0], (struct spdk_uuid*)&group_id_to_delete.data[0]) == 0) {
             group_to_delete = current_group;
             break;
         }
-        list_node = xsan_list_node_next(list_node);
+        list_node_group = xsan_list_node_next(list_node_group);
     }
 
     if (group_to_delete) {
-        // TODO: Check if group is busy (e.g., has active volumes). For now, allow deletion.
-        XSAN_LOG_INFO("Deleting disk group '%s' (ID: %s)...", group_to_delete->name, spdk_uuid_get_string((struct spdk_uuid*)&group_to_delete->id.data[0]));
+        char group_id_str_log[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(group_id_str_log, sizeof(group_id_str_log), (struct spdk_uuid*)&group_to_delete->id.data[0]);
+        XSAN_LOG_INFO("Deleting disk group '%s' (ID: %s)...", group_to_delete->name, group_id_str_log);
 
-        // Unassign disks from this group
         for (uint32_t i = 0; i < group_to_delete->disk_count; ++i) {
-            xsan_disk_t *disk = xsan_disk_manager_find_disk_by_id(dm, group_to_delete->disk_ids[i]);
+            xsan_disk_t *disk = NULL; // Find without holding lock for long
+            xsan_list_node_t *disk_node_iter;
+            XSAN_LIST_FOREACH(dm->managed_disks, disk_node_iter) {
+                xsan_disk_t *d_iter = (xsan_disk_t *)xsan_list_node_get_value(disk_node_iter);
+                if(spdk_uuid_compare((struct spdk_uuid*)&d_iter->id.data[0], (struct spdk_uuid*)&group_to_delete->disk_ids[i].data[0]) == 0) {
+                    disk = d_iter;
+                    break;
+                }
+            }
             if (disk) {
-                // Check if the disk was indeed assigned to this group before clearing, to be safe
                 if(spdk_uuid_compare((struct spdk_uuid*)&disk->assigned_to_group_id.data[0], (struct spdk_uuid*)&group_to_delete->id.data[0]) == 0) {
-                    memset(&disk->assigned_to_group_id, 0, sizeof(xsan_group_id_t)); // Mark as unassigned
-                    XSAN_LOG_DEBUG("Disk '%s' (bdev: %s) unassigned from deleted group.", spdk_uuid_get_string((struct spdk_uuid*)&disk->id.data[0]), disk->bdev_name);
+                    memset(&disk->assigned_to_group_id, 0, sizeof(xsan_group_id_t));
+                    char disk_id_str_log[SPDK_UUID_STRING_LEN];
+                    spdk_uuid_fmt_lower(disk_id_str_log, sizeof(disk_id_str_log), (struct spdk_uuid*)&disk->id.data[0]);
+                    XSAN_LOG_DEBUG("Disk '%s' (bdev: %s) unassigned from deleted group.", disk_id_str_log, disk->bdev_name);
                 }
             }
         }
 
-        // xsan_list_remove_node will call the _xsan_internal_disk_group_destroy_cb, which frees the group.
-        xsan_list_remove_node(dm->managed_disk_groups, list_node);
+        xsan_list_remove_node(dm->managed_disk_groups, list_node_group);
         err = XSAN_OK;
-        XSAN_LOG_INFO("Disk group (ID: %s) deleted successfully.", spdk_uuid_get_string((struct spdk_uuid*)&group_id_to_delete.data[0]));
+        XSAN_LOG_INFO("Disk group (ID: %s) deleted successfully.", group_id_str_log);
     } else {
-        XSAN_LOG_WARN("Disk group (ID: %s) not found for deletion.", spdk_uuid_get_string((struct spdk_uuid*)&group_id_to_delete.data[0]));
+        char group_id_str_log[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(group_id_str_log, sizeof(group_id_str_log), (struct spdk_uuid*)&group_id_to_delete.data[0]);
+        XSAN_LOG_WARN("Disk group (ID: %s) not found for deletion.", group_id_str_log);
     }
 
     pthread_mutex_unlock(&dm->lock);
@@ -522,7 +529,7 @@ xsan_error_t xsan_disk_manager_get_all_disk_groups(xsan_disk_manager_t *dm, xsan
     int i = 0;
     xsan_list_node_t *node;
     XSAN_LIST_FOREACH(dm->managed_disk_groups, node) {
-         if (i < (int)num_groups) { // Defensive check
+         if (i < (int)num_groups) {
             (*groups_array_out)[i++] = (xsan_disk_group_t *)xsan_list_node_get_value(node);
         } else {
             break;
@@ -534,7 +541,7 @@ xsan_error_t xsan_disk_manager_get_all_disk_groups(xsan_disk_manager_t *dm, xsan
 }
 
 void xsan_disk_manager_free_group_pointer_list(xsan_disk_group_t **group_ptr_array) {
-    if (group_ptr_array) {
+     if (group_ptr_array) {
         XSAN_FREE(group_ptr_array);
     }
 }
@@ -557,8 +564,7 @@ xsan_disk_group_t *xsan_disk_manager_find_disk_group_by_id(xsan_disk_manager_t *
 }
 
 xsan_disk_group_t *xsan_disk_manager_find_disk_group_by_name(xsan_disk_manager_t *dm, const char *name) {
-    if (!dm || !dm->initialized || !name) return NULL;
-
+     if (!dm || !dm->initialized || !name) return NULL;
     pthread_mutex_lock(&dm->lock);
     xsan_list_node_t *node;
     xsan_disk_group_t *found_group = NULL;
@@ -572,8 +578,3 @@ xsan_disk_group_t *xsan_disk_manager_find_disk_group_by_name(xsan_disk_manager_t
     pthread_mutex_unlock(&dm->lock);
     return found_group;
 }
-
-// A new directory `src/storage` will be implicitly created by this.
-// Ensure CMakeLists.txt in `src` adds `add_subdirectory(storage)`
-// and `src/storage/CMakeLists.txt` compiles this file into a library.
-// (These CMake changes are part of a later step in the plan).

--- a/src/storage/volume_manager.c
+++ b/src/storage/volume_manager.c
@@ -6,6 +6,7 @@
 #include "xsan_string_utils.h" // For xsan_strcpy_safe
 #include "xsan_log.h"
 #include "xsan_error.h"
+#include "xsan_io.h"           // For xsan_io_request_t and submission functions
 
 #include "spdk/uuid.h"         // For spdk_uuid_generate, spdk_uuid_compare, spdk_uuid_is_null
 #include <pthread.h>           // For pthread_mutex_t
@@ -27,7 +28,6 @@ static void _xsan_internal_volume_destroy_cb(void *volume_data) {
         xsan_volume_t *vol = (xsan_volume_t *)volume_data;
         XSAN_LOG_DEBUG("Volume Manager: Destroying xsan_volume (Name: '%s', ID: %s)",
                        vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]));
-        // If volume had allocated extents or other resources, free them here.
         XSAN_FREE(vol);
     }
 }
@@ -68,7 +68,7 @@ xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *disk_manager, xsan_vo
         return XSAN_ERROR_SYSTEM;
     }
 
-    vm->disk_manager = disk_manager; // Store reference to disk manager
+    vm->disk_manager = disk_manager;
     vm->initialized = true;
     g_xsan_volume_manager_instance = vm;
     if (vm_instance_out) {
@@ -76,8 +76,6 @@ xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *disk_manager, xsan_vo
     }
 
     XSAN_LOG_INFO("XSAN Volume Manager initialized successfully.");
-    // In a real system, load existing volume metadata from persistent storage here.
-    // e.g., xsan_volume_manager_load_metadata(vm);
     return XSAN_OK;
 }
 
@@ -99,8 +97,6 @@ void xsan_volume_manager_fini(xsan_volume_manager_t **vm_ptr) {
     XSAN_LOG_INFO("Finalizing XSAN Volume Manager...");
     pthread_mutex_lock(&vm_to_fini->lock);
 
-    // In a real system, save volume metadata to persistent storage before destroying.
-    // e.g., xsan_volume_manager_save_metadata(vm_to_fini);
     xsan_list_destroy(vm_to_fini->managed_volumes);
     vm_to_fini->managed_volumes = NULL;
     vm_to_fini->disk_manager = NULL;
@@ -127,7 +123,7 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
                                 bool thin_provisioned,
                                 xsan_volume_id_t *new_volume_id_out) {
     if (!vm || !vm->initialized || !name || size_bytes == 0 || logical_block_size_bytes == 0 ||
-        (logical_block_size_bytes & (logical_block_size_bytes - 1)) != 0 || // Must be power of 2
+        (logical_block_size_bytes & (logical_block_size_bytes - 1)) != 0 ||
         spdk_uuid_is_null((struct spdk_uuid*)&group_id.data[0])) {
         return XSAN_ERROR_INVALID_PARAM;
     }
@@ -139,7 +135,6 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
     pthread_mutex_lock(&vm->lock);
     xsan_error_t err = XSAN_OK;
 
-    // Check if volume name already exists (must be done while holding vm->lock)
     xsan_list_node_t *iter_node;
     XSAN_LIST_FOREACH(vm->managed_volumes, iter_node) {
         xsan_volume_t *vol_iter = (xsan_volume_t*)xsan_list_node_get_value(iter_node);
@@ -149,7 +144,6 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
             return XSAN_ERROR_ALREADY_EXISTS;
         }
     }
-    // xsan_volume_get_by_name also locks, so direct iteration is better here.
 
     xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, group_id);
     if (!group) {
@@ -166,8 +160,6 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
         goto cleanup_unlock;
     }
 
-    // TODO: More sophisticated capacity check involving actual free space on group, not just usable.
-    // For now, a simple check for thick provisioning.
     if (!thin_provisioned && size_bytes > group->usable_capacity_bytes) {
         XSAN_LOG_ERROR("Insufficient usable capacity in disk group '%s' for volume '%s'. Required: %lu, Usable: %lu",
                        group->name, name, size_bytes, group->usable_capacity_bytes);
@@ -187,7 +179,7 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
     new_volume->size_bytes = size_bytes;
     new_volume->block_size_bytes = logical_block_size_bytes;
     new_volume->num_blocks = size_bytes / logical_block_size_bytes;
-    new_volume->state = XSAN_STORAGE_STATE_ONLINE; // Initial state
+    new_volume->state = XSAN_STORAGE_STATE_ONLINE;
     memcpy(&new_volume->source_group_id, &group_id, sizeof(xsan_group_id_t));
     new_volume->thin_provisioned = thin_provisioned;
     new_volume->allocated_bytes = thin_provisioned ? 0 : size_bytes;
@@ -235,13 +227,11 @@ xsan_error_t xsan_volume_delete(xsan_volume_manager_t *vm, xsan_volume_id_t volu
     }
 
     if (volume_to_delete) {
-        // TODO: Check if volume is busy (e.g., mounted).
-        // TODO: Release allocated space (needs extent tracking / block allocator for the group).
         char vol_uuid_str_log[SPDK_UUID_STRING_LEN];
         spdk_uuid_fmt_lower(vol_uuid_str_log, sizeof(vol_uuid_str_log), (struct spdk_uuid*)&volume_to_delete->id.data[0]);
         XSAN_LOG_INFO("Deleting volume '%s' (ID: %s)...", volume_to_delete->name, vol_uuid_str_log);
 
-        xsan_list_remove_node(vm->managed_volumes, list_node); // This calls _xsan_internal_volume_destroy_cb
+        xsan_list_remove_node(vm->managed_volumes, list_node);
         err = XSAN_OK;
         XSAN_LOG_INFO("Volume (ID: %s) deleted successfully.", vol_uuid_str_log);
     } else {
@@ -337,42 +327,23 @@ xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
                                              xsan_volume_id_t volume_id,
                                              uint64_t logical_block_idx,
                                              xsan_disk_id_t *out_disk_id,
-                                             uint64_t *out_physical_block_idx) {
-    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0]) || !out_disk_id || !out_physical_block_idx) {
+                                             uint64_t *out_physical_block_idx,
+                                             uint32_t *out_physical_block_size) {
+    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])
+        || !out_disk_id || !out_physical_block_idx || !out_physical_block_size) {
         return XSAN_ERROR_INVALID_PARAM;
     }
 
-    pthread_mutex_lock(&vm->lock);
-    xsan_volume_t *vol = NULL;
-    xsan_list_node_t *iter_node;
-    XSAN_LIST_FOREACH(vm->managed_volumes, iter_node) {
-        xsan_volume_t *v = (xsan_volume_t*)xsan_list_node_get_value(iter_node);
-        if(spdk_uuid_compare((struct spdk_uuid*)&v->id.data[0], (struct spdk_uuid*)&volume_id.data[0]) == 0) {
-            vol = v;
-            break;
-        }
-    }
-
+    xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id); // This locks/unlocks vm->lock
     if (!vol) {
-        pthread_mutex_unlock(&vm->lock);
         return XSAN_ERROR_NOT_FOUND;
     }
 
     if (logical_block_idx >= vol->num_blocks) {
-        pthread_mutex_unlock(&vm->lock);
         return XSAN_ERROR_OUT_OF_BOUNDS;
     }
 
-    // Get the source disk group - xsan_disk_manager_find_disk_group_by_id is thread-safe itself
-    // No need to hold vm->lock while calling disk_manager if disk_manager is also properly locked.
-    // However, vol->source_group_id read should be under lock.
-    xsan_group_id_t src_group_id;
-    memcpy(&src_group_id, &vol->source_group_id, sizeof(xsan_group_id_t));
-    pthread_mutex_unlock(&vm->lock); // Release vm lock before calling dm, if dm is also locked.
-                                     // Or, ensure dm calls don't re-lock if already holding vm->lock (complex).
-                                     // For now, assume dm calls are safe.
-
-    xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, src_group_id);
+    xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, vol->source_group_id);
     if (!group) {
         XSAN_LOG_ERROR("Volume '%s' (ID: %s) source group ID not found.", vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]));
         return XSAN_ERROR_NOT_FOUND;
@@ -383,16 +354,15 @@ xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
         return XSAN_ERROR_STORAGE_GENERIC;
     }
 
-    // --- Simple Mapping Logic (Phase 1: Volume maps linearly to the first disk in the group) ---
-    // This is a highly simplified placeholder. Real mapping involves extent management,
-    // striping, replication, tiering, etc.
-    xsan_disk_id_t target_disk_id_from_group; // This is xsan_disk_id_t (UUID)
+    xsan_disk_id_t target_disk_id_from_group;
     memcpy(&target_disk_id_from_group, &group->disk_ids[0], sizeof(xsan_disk_id_t));
 
     xsan_disk_t *target_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, target_disk_id_from_group);
 
     if (!target_disk) {
-        XSAN_LOG_ERROR("Target disk (ID: %s) for volume '%s' not found in disk manager.", spdk_uuid_get_string((struct spdk_uuid*)&target_disk_id_from_group.data[0]), vol->name);
+        char disk_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(disk_id_str, sizeof(disk_id_str), (struct spdk_uuid*)&target_disk_id_from_group.data[0]);
+        XSAN_LOG_ERROR("Target disk (ID: %s) for volume '%s' not found in disk manager.", disk_id_str, vol->name);
         return XSAN_ERROR_NOT_FOUND;
     }
 
@@ -401,22 +371,145 @@ xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
          return XSAN_ERROR_STORAGE_GENERIC;
     }
 
-    // Calculate physical block index on the target disk.
-    // This assumes the volume's logical blocks are mapped 1:1 or N:1 to target disk blocks
-    // if block sizes differ.
-    // Physical offset in bytes = logical_block_idx * vol->block_size_bytes
-    // Physical block on target disk = (Physical offset in bytes) / target_disk->block_size_bytes
+    *out_physical_block_size = target_disk->block_size_bytes;
+    // Physical LBA on disk = (logical_block_idx_within_volume * volume_logical_block_size) / physical_disk_block_size
+    // This assumes the volume starts at physical block 0 of the target_disk for this simple mapping.
     *out_physical_block_idx = (logical_block_idx * vol->block_size_bytes) / target_disk->block_size_bytes;
 
-    // Ensure this physical block index is within the target disk's capacity
-    uint64_t required_physical_blocks_for_this_lba = (vol->block_size_bytes + target_disk->block_size_bytes -1) / target_disk->block_size_bytes;
-    if (*out_physical_block_idx + (required_physical_blocks_for_this_lba -1) >= target_disk->num_blocks) {
-         XSAN_LOG_ERROR("LBA mapping for volume '%s' (LBA %lu) exceeds capacity of target disk '%s'.",
-                        vol->name, logical_block_idx, target_disk->bdev_name);
+    // Check if the mapping makes sense for the target disk capacity
+    uint64_t num_physical_blocks_needed_for_logical_block =
+        (vol->block_size_bytes + target_disk->block_size_bytes - 1) / target_disk->block_size_bytes;
+
+    if ((*out_physical_block_idx + num_physical_blocks_needed_for_logical_block -1) >= target_disk->num_blocks) {
+         XSAN_LOG_ERROR("LBA mapping for volume '%s' (LBA_idx %lu) exceeds capacity of target disk '%s'. Calculated phys_idx %lu (needs %lu blocks), disk blocks %lu",
+                        vol->name, logical_block_idx, target_disk->bdev_name, *out_physical_block_idx, num_physical_blocks_needed_for_logical_block, target_disk->num_blocks);
         return XSAN_ERROR_OUT_OF_BOUNDS;
     }
 
-    memcpy(out_disk_id, &target_disk->id, sizeof(xsan_disk_id_t)); // Copy the XSAN ID of the disk
+    memcpy(out_disk_id, &target_disk->id, sizeof(xsan_disk_id_t));
 
     return XSAN_OK;
+}
+
+// Helper function for common async I/O logic
+static xsan_error_t _xsan_volume_submit_async_io(
+    xsan_volume_manager_t *vm,
+    xsan_volume_id_t volume_id,
+    uint64_t logical_byte_offset,
+    uint64_t length_bytes,
+    void *user_buf,
+    bool is_read_op,
+    xsan_user_io_completion_cb_t user_cb,
+    void *user_cb_arg) {
+
+    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0]) || !user_buf || length_bytes == 0 || !user_cb) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id);
+    if (!vol) {
+        return XSAN_ERROR_NOT_FOUND;
+    }
+
+    if (vol->block_size_bytes == 0 || (logical_byte_offset % vol->block_size_bytes != 0) || (length_bytes % vol->block_size_bytes != 0)) {
+        XSAN_LOG_ERROR("Volume I/O for '%s' has unaligned offset/length (off=%lu, len=%lu, vol_blk_size=%u)",
+                       vol->name, logical_byte_offset, length_bytes, vol->block_size_bytes);
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    uint64_t logical_start_block_idx = logical_byte_offset / vol->block_size_bytes;
+    uint64_t num_logical_blocks_in_io = length_bytes / vol->block_size_bytes;
+
+
+    if ((logical_start_block_idx + num_logical_blocks_in_io) > vol->num_blocks) {
+         XSAN_LOG_ERROR("I/O request for volume '%s' (start_lba %lu, num_lba %lu) exceeds volume size (%lu blocks).",
+                       vol->name, logical_start_block_idx, num_logical_blocks_in_io, vol->num_blocks);
+        return XSAN_ERROR_OUT_OF_BOUNDS;
+    }
+
+    // --- LBA to PBA mapping ---
+    // For this simple version, we assume the I/O maps to a single contiguous region on one physical disk.
+    // A more complex I/O could span multiple physical disks or extents.
+    xsan_disk_id_t physical_disk_id;
+    uint64_t physical_start_block_idx_on_disk;
+    uint32_t physical_bdev_block_size;
+
+    xsan_error_t map_err = xsan_volume_map_lba_to_physical(vm, volume_id, logical_start_block_idx,
+                                                           &physical_disk_id, &physical_start_block_idx_on_disk,
+                                                           &physical_bdev_block_size);
+    if (map_err != XSAN_OK) {
+        XSAN_LOG_ERROR("Failed to map LBA for volume '%s': %s", vol->name, xsan_error_string(map_err));
+        return map_err;
+    }
+
+    xsan_disk_t *target_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, physical_disk_id);
+    if (!target_disk) {
+        char disk_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(disk_id_str, sizeof(disk_id_str), (struct spdk_uuid*)&physical_disk_id.data[0]);
+        XSAN_LOG_ERROR("Target disk (ID: %s) from LBA mapping not found for volume '%s'.", disk_id_str, vol->name);
+        return XSAN_ERROR_NOT_FOUND;
+    }
+
+    // The actual number of physical blocks to read/write.
+    // length_bytes is already a multiple of vol->block_size_bytes.
+    // It must also be a multiple of physical_bdev_block_size.
+    if (length_bytes % physical_bdev_block_size != 0) {
+         XSAN_LOG_ERROR("I/O length %lu for vol '%s' is not a multiple of target physical bdev block size %u.",
+                        length_bytes, vol->name, physical_bdev_block_size);
+        return XSAN_ERROR_INVALID_PARAM; // Alignment issue not handled by simple mapping
+    }
+    uint32_t num_physical_blocks_for_io = length_bytes / physical_bdev_block_size;
+
+    // Create xsan_io_request_t
+    // Pass physical bdev block size as the block_size_bytes for the io_request.
+    // The offset_bytes for io_request is physical_start_block_idx_on_disk * physical_bdev_block_size.
+    xsan_io_request_t *io_req = xsan_io_request_create(
+        volume_id, user_buf,
+        physical_start_block_idx_on_disk * physical_bdev_block_size, // Physical byte offset on target bdev
+        length_bytes,                                                // Total length in bytes remains same
+        physical_bdev_block_size,                                    // Block size for this specific IO is physical
+        is_read_op, user_cb, user_cb_arg);
+    if (!io_req) {
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+
+    memcpy(&io_req->target_disk_id, &target_disk->id, sizeof(xsan_disk_id_t));
+    xsan_strcpy_safe(io_req->target_bdev_name, target_disk->bdev_name, XSAN_MAX_NAME_LEN);
+
+    // These should already be correctly set by xsan_io_request_create based on physical params
+    // io_req->offset_blocks = physical_start_block_idx_on_disk;
+    // io_req->num_blocks = num_physical_blocks_for_io;
+
+    xsan_error_t submit_err = xsan_io_submit_request_to_bdev(io_req);
+    if (submit_err != XSAN_OK) {
+        XSAN_LOG_ERROR("Failed to submit async IO for volume '%s' to bdev '%s': %s",
+                       vol->name, target_disk->bdev_name, xsan_error_string(submit_err));
+        // xsan_io_submit_request_to_bdev calls user_cb with error and frees io_req on submission failure itself.
+        return submit_err;
+    }
+
+    return XSAN_OK;
+}
+
+
+xsan_error_t xsan_volume_read_async(xsan_volume_manager_t *vm,
+                                    xsan_volume_id_t volume_id,
+                                    uint64_t logical_byte_offset,
+                                    uint64_t length_bytes,
+                                    void *user_buf,
+                                    xsan_user_io_completion_cb_t user_cb,
+                                    void *user_cb_arg) {
+    return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes,
+                                        user_buf, true, user_cb, user_cb_arg);
+}
+
+xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm,
+                                     xsan_volume_id_t volume_id,
+                                     uint64_t logical_byte_offset,
+                                     uint64_t length_bytes,
+                                     const void *user_buf,
+                                     xsan_user_io_completion_cb_t user_cb,
+                                     void *user_cb_arg) {
+    return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes,
+                                        (void*)user_buf, false, user_cb, user_cb_arg);
 }


### PR DESCRIPTION
- Defined xsan_io.h with xsan_io_request_t for managing async I/O operations and xsan_user_io_completion_cb_t for your callbacks.
- Implemented xsan_io.c to handle the lifecycle of xsan_io_request_t, perform I/O to SPDK bdevs asynchronously, and manage DMA buffers. The SPDK completion callback in xsan_io.c now invokes your callback.
- Refined SPDK resource management: xsan_disk_t now holds the spdk_bdev_desc*, and xsan_io.c manages spdk_io_channel per request using this descriptor.
- Implemented xsan_volume_read_async() and xsan_volume_write_async() in xsan_volume_manager.c. These functions perform LBA-to-PBA mapping, create an xsan_io_request_t, and use xsan_io_submit_request_to_bdev.
- Updated xsan_volume_map_lba_to_physical to also return physical block size.
- Updated CMake build system to include the new 'io' module (xsan_io library) and link it appropriately with the xsan_storage library.
- Modified xsan_node.c to test the new asynchronous volume I/O path:
  - Uses a state machine and callbacks for write-then-read-then-verify.
  - Includes a polling loop in the main SPDK app function to wait for async I/O completion before shutting down.