### PR TITLE
Add replication metadata to volumes and persistence

### DIFF
--- a/src/include/xsan_volume_manager.h
+++ b/src/include/xsan_volume_manager.h
@@ -61,6 +61,7 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
                                 xsan_group_id_t group_id,
                                 uint32_t logical_block_size_bytes,
                                 bool thin_provisioned,
+                                uint32_t ftt, // Failures To Tolerate
                                 xsan_volume_id_t *new_volume_id_out);
 
 /**

--- a/src/main/xsan_node.c
+++ b/src/main/xsan_node.c
@@ -5,7 +5,7 @@
 #include "xsan_disk_manager.h"
 #include "xsan_volume_manager.h"
 #include "xsan_io.h"
-#include "xsan_node_comm.h"     // For node communication module
+#include "xsan_node_comm.h"
 #include "xsan_error.h"
 #include "xsan_string_utils.h"
 
@@ -19,7 +19,7 @@
 #include "spdk/uuid.h"
 #include "spdk/env.h"
 #include "spdk/sock.h"
-#include "spdk/thread.h" // For spdk_thread_get_id
+#include "spdk/thread.h"
 
 // --- Async I/O Test Context and Callbacks ---
 typedef struct {
@@ -34,7 +34,7 @@ typedef struct {
     enum { ASYNC_IO_TEST_IDLE, ASYNC_IO_TEST_WRITE_SUBMITTED, ASYNC_IO_TEST_READ_SUBMITTED,
            ASYNC_IO_TEST_VERIFY_DONE, ASYNC_IO_TEST_FAILED } test_state;
     int outstanding_io_ops;
-    bool test_finished_signal; // Combined signal for this test path
+    bool test_finished_signal;
 } xsan_async_io_test_control_t;
 static xsan_async_io_test_control_t g_async_io_test_controller;
 
@@ -44,12 +44,11 @@ typedef struct {
     bool connected_to_self;
     bool ping_sent_successfully;
     bool pong_received_or_ping_handled;
-    bool test_finished_signal; // Combined signal for this test path
+    bool test_finished_signal;
 } xsan_comm_test_state_t;
 static xsan_comm_test_state_t g_comm_test_controller;
 
 
-// Forward declarations for async test helpers
 static void _run_async_io_test_read_phase(xsan_async_io_test_control_t *test_ctrl);
 static void _finalize_async_io_test(xsan_async_io_test_control_t *test_ctrl);
 
@@ -58,118 +57,130 @@ static void _async_io_test_read_complete_cb(void *cb_arg, xsan_error_t status) {
     test_ctrl->outstanding_io_ops--;
     char vol_id_str[SPDK_UUID_STRING_LEN];
     spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
-    if (status != XSAN_OK) { /* ... log error ... */ test_ctrl->test_state = ASYNC_IO_TEST_FAILED; }
-    else { /* ... log success, memcmp ... */
+    if (status != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncIOTest] Read from volume %s FAILED: %s (code %d)", vol_id_str, xsan_error_string(status), status);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+    } else {
+        XSAN_LOG_INFO("[AsyncIOTest] Read from volume %s successful.", vol_id_str);
         if (memcmp(test_ctrl->write_buffer_dma, test_ctrl->read_buffer_dma, test_ctrl->io_block_size) == 0) {
             XSAN_LOG_INFO("SUCCESS: [AsyncIOTest] R/W data verification for volume %s PASSED!", vol_id_str);
             test_ctrl->test_state = ASYNC_IO_TEST_VERIFY_DONE;
-        } else { XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W data verification for volume %s FAILED!", vol_id_str); test_ctrl->test_state = ASYNC_IO_TEST_FAILED; }
+        } else {
+            XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W data verification for volume %s FAILED!", vol_id_str);
+            test_ctrl->test_state = ASYNC_IO_TEST_FAILED;
+        }
     }
     _finalize_async_io_test(test_ctrl);
 }
+
 static void _run_async_io_test_read_phase(xsan_async_io_test_control_t *test_ctrl) {
-    /* ... submit async read ... */
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+    XSAN_LOG_DEBUG("[AsyncIOTest] Submitting async read for volume %s...", vol_id_str);
     test_ctrl->test_state = ASYNC_IO_TEST_READ_SUBMITTED; test_ctrl->outstanding_io_ops++;
     xsan_error_t err = xsan_volume_read_async(test_ctrl->vm, test_ctrl->volume_id_to_test, 0, test_ctrl->io_block_size, test_ctrl->read_buffer_dma, _async_io_test_read_complete_cb, test_ctrl);
-    if (err != XSAN_OK) { /* ... log error, dec ops, set fail state, finalize ... */ test_ctrl->outstanding_io_ops--; test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl); }
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncIOTest] Failed to submit async read for vol %s: %s", vol_id_str, xsan_error_string(err));
+        test_ctrl->outstanding_io_ops--; test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl);
+    }
 }
+
 static void _async_io_test_write_complete_cb(void *cb_arg, xsan_error_t status) {
     xsan_async_io_test_control_t *test_ctrl = (xsan_async_io_test_control_t *)cb_arg;
     test_ctrl->outstanding_io_ops--;
-    if (status != XSAN_OK) { /* ... log error, set fail state, finalize ... */ test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl); }
-    else { _run_async_io_test_read_phase(test_ctrl); }
+    char vol_id_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+    if (status != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncIOTest] Write to volume %s FAILED: %s (code %d)", vol_id_str, xsan_error_string(status), status);
+        test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl);
+    }
+    else {
+        XSAN_LOG_INFO("[AsyncIOTest] Write to volume %s successful. Reading back...", vol_id_str);
+        _run_async_io_test_read_phase(test_ctrl);
+    }
 }
+
 static void _start_async_io_test_on_volume(xsan_async_io_test_control_t *test_ctrl, xsan_volume_t *vol_to_test) {
-    /* ... setup test_ctrl, alloc DMA bufs, fill write_buf ... */
-    if (!vol_to_test || vol_to_test->block_size_bytes == 0 || vol_to_test->num_blocks == 0) { _finalize_async_io_test(test_ctrl); return; }
+    if (!vol_to_test || vol_to_test->block_size_bytes == 0 || vol_to_test->num_blocks == 0) {
+        XSAN_LOG_WARN("[AsyncIOTest] Invalid volume for test. Skipping.");
+        _finalize_async_io_test(test_ctrl); return;
+    }
     memcpy(&test_ctrl->volume_id_to_test, &vol_to_test->id, sizeof(xsan_volume_id_t));
     test_ctrl->io_block_size = vol_to_test->block_size_bytes;
     xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(test_ctrl->dm, vol_to_test->source_group_id);
-    if (!group || group->disk_count == 0) { _finalize_async_io_test(test_ctrl); return; }
+    if (!group || group->disk_count == 0) { XSAN_LOG_ERROR("[AsyncIOTest] Vol group invalid. Skipping."); _finalize_async_io_test(test_ctrl); return; }
     xsan_disk_t *first_disk_in_group = xsan_disk_manager_find_disk_by_id(test_ctrl->dm, group->disk_ids[0]);
-    if (!first_disk_in_group) { _finalize_async_io_test(test_ctrl); return; }
+    if (!first_disk_in_group) { XSAN_LOG_ERROR("[AsyncIOTest] Vol disk invalid. Skipping."); _finalize_async_io_test(test_ctrl); return; }
+
     xsan_strcpy_safe(test_ctrl->target_bdev_name_for_log, first_disk_in_group->bdev_name, XSAN_MAX_NAME_LEN);
     test_ctrl->dma_alignment = xsan_bdev_get_buf_align(first_disk_in_group->bdev_name);
     test_ctrl->write_buffer_dma = xsan_bdev_dma_malloc(test_ctrl->io_block_size, test_ctrl->dma_alignment);
     test_ctrl->read_buffer_dma = xsan_bdev_dma_malloc(test_ctrl->io_block_size, test_ctrl->dma_alignment);
-    if (!test_ctrl->write_buffer_dma || !test_ctrl->read_buffer_dma) { /* free, finalize */ _finalize_async_io_test(test_ctrl); return; }
+
+    if (!test_ctrl->write_buffer_dma || !test_ctrl->read_buffer_dma) {
+        XSAN_LOG_ERROR("[AsyncIOTest] DMA alloc failed. Skipping.");
+        if(test_ctrl->write_buffer_dma) xsan_bdev_dma_free(test_ctrl->write_buffer_dma);
+        if(test_ctrl->read_buffer_dma) xsan_bdev_dma_free(test_ctrl->read_buffer_dma);
+        test_ctrl->write_buffer_dma = NULL; test_ctrl->read_buffer_dma = NULL;
+        _finalize_async_io_test(test_ctrl); return;
+    }
+
     char vol_id_str[SPDK_UUID_STRING_LEN]; spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
     snprintf((char*)test_ctrl->write_buffer_dma, test_ctrl->io_block_size, "XSAN Async Test! Vol %s", vol_id_str);
     for(size_t k=strlen((char*)test_ctrl->write_buffer_dma); k < test_ctrl->io_block_size; ++k) { ((char*)test_ctrl->write_buffer_dma)[k] = (char)((k % 250) + 5); }
     memset(test_ctrl->read_buffer_dma, 0xDD, test_ctrl->io_block_size);
-    XSAN_LOG_INFO("--- Starting Async R/W Test on Volume ID %s ---", vol_id_str);
+    XSAN_LOG_INFO("--- Starting Async R/W Test on Volume ID %s (bdev: '%s', io_block_size: %u) ---", vol_id_str, test_ctrl->target_bdev_name_for_log, test_ctrl->io_block_size);
+
     test_ctrl->test_state = ASYNC_IO_TEST_WRITE_SUBMITTED; test_ctrl->outstanding_io_ops++;
     xsan_error_t err = xsan_volume_write_async(test_ctrl->vm, test_ctrl->volume_id_to_test, 0, test_ctrl->io_block_size, test_ctrl->write_buffer_dma, _async_io_test_write_complete_cb, test_ctrl);
-    if (err != XSAN_OK) { /* free bufs, dec ops, set fail, finalize */ test_ctrl->outstanding_io_ops--; test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl); }
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("[AsyncIOTest] Failed to submit async write for vol %s: %s", vol_id_str, xsan_error_string(err));
+        test_ctrl->outstanding_io_ops--; test_ctrl->test_state = ASYNC_IO_TEST_FAILED; _finalize_async_io_test(test_ctrl);
+    }
 }
+
 static void _finalize_async_io_test(xsan_async_io_test_control_t *test_ctrl) {
     if (test_ctrl->outstanding_io_ops == 0) {
-        XSAN_LOG_INFO("[AsyncIOTest] Sequence finished, state: %d.", test_ctrl->test_state);
+        char vol_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
+        XSAN_LOG_INFO("[AsyncIOTest] Sequence finished for volume %s, state: %d.", vol_id_str, test_ctrl->test_state);
         if(test_ctrl->write_buffer_dma) xsan_bdev_dma_free(test_ctrl->write_buffer_dma); test_ctrl->write_buffer_dma = NULL;
         if(test_ctrl->read_buffer_dma) xsan_bdev_dma_free(test_ctrl->read_buffer_dma); test_ctrl->read_buffer_dma = NULL;
-        test_ctrl->test_finished_signal = true; // Signal main SPDK app func
+        test_ctrl->test_finished_signal = true;
     }
 }
 
 // --- Node Comm Test Callbacks & State ---
 static void _comm_test_send_ping_cb(int status, void *cb_arg) {
     xsan_comm_test_state_t *comm_state = (xsan_comm_test_state_t *)cb_arg;
-    if (status == 0) {
-        XSAN_LOG_INFO("[CommTest] Successfully sent PING message to self.");
-        comm_state->ping_sent_successfully = true;
-        // Now wait for handler to receive it and set pong_received_or_ping_handled
-    } else {
-        XSAN_LOG_ERROR("[CommTest] Failed to send PING message to self, status: %d", status);
-        comm_state->test_finished_signal = true; // End test on send failure
-    }
+    if (status == 0) { XSAN_LOG_INFO("[CommTest] Successfully sent PING to self."); comm_state->ping_sent_successfully = true; }
+    else { XSAN_LOG_ERROR("[CommTest] Failed to send PING to self, status: %d", status); comm_state->test_finished_signal = true; }
 }
-
 static void _comm_test_connect_cb(struct spdk_sock *sock, int status, void *cb_arg) {
     xsan_comm_test_state_t *comm_state = (xsan_comm_test_state_t *)cb_arg;
     if (status == 0) {
-        XSAN_LOG_INFO("[CommTest] Successfully connected to self (sock %p)!", sock);
-        comm_state->client_sock_to_self = sock;
-        comm_state->connected_to_self = true;
-
-        xsan_message_t *ping_msg = xsan_protocol_message_create(
-            XSAN_MSG_TYPE_HEARTBEAT, // Use HEARTBEAT as PING
-            (uint64_t)spdk_env_get_current_core() << 32 | 0x1234, // Example TID
-            "SELF_PING", strlen("SELF_PING") + 1);
-
+        XSAN_LOG_INFO("[CommTest] Connected to self (sock %p)!", sock);
+        comm_state->client_sock_to_self = sock; comm_state->connected_to_self = true;
+        xsan_message_t *ping_msg = xsan_protocol_message_create(XSAN_MSG_TYPE_HEARTBEAT, (uint64_t)spdk_env_get_current_core() << 32 | 0xABCD, "SELF_PING_PAYLOAD", strlen("SELF_PING_PAYLOAD") + 1);
         if (ping_msg) {
-            XSAN_LOG_INFO("[CommTest] Sending PING message to self...");
-            xsan_error_t send_err = xsan_node_comm_send_msg(sock, ping_msg, _comm_test_send_ping_cb, comm_state);
-            if (send_err != XSAN_OK) {
-                XSAN_LOG_ERROR("[CommTest] Failed to initiate send for PING: %s", xsan_error_string(send_err));
-                comm_state->test_finished_signal = true;
+            XSAN_LOG_INFO("[CommTest] Sending PING to self...");
+            if (xsan_node_comm_send_msg(sock, ping_msg, _comm_test_send_ping_cb, comm_state) != XSAN_OK) {
+                XSAN_LOG_ERROR("[CommTest] Failed to initiate PING send."); comm_state->test_finished_signal = true;
             }
             xsan_protocol_message_destroy(ping_msg);
-        } else {
-            XSAN_LOG_ERROR("[CommTest] Failed to create PING message.");
-            comm_state->test_finished_signal = true;
-        }
-    } else {
-        XSAN_LOG_ERROR("[CommTest] Failed to connect to self, status: %d", status);
-        comm_state->test_finished_signal = true;
-    }
+        } else { XSAN_LOG_ERROR("[CommTest] Failed to create PING msg."); comm_state->test_finished_signal = true; }
+    } else { XSAN_LOG_ERROR("[CommTest] Failed to connect to self, status: %d", status); comm_state->test_finished_signal = true; }
 }
-
-// Main message handler for the node
-static void _xsan_node_test_message_handler(struct spdk_sock *sock,
-                                            const char *peer_addr_str,
-                                            xsan_message_t *msg,
-                                            void *cb_arg) {
+static void _xsan_node_test_message_handler(struct spdk_sock *sock, const char *peer_addr_str, xsan_message_t *msg, void *cb_arg) {
     (void)sock; (void)cb_arg;
-    XSAN_LOG_INFO("[TestMsgHandler] Received message from %s: Type %u", peer_addr_str, msg->header.type);
-
-    if (msg->header.type == XSAN_MSG_TYPE_HEARTBEAT && msg->payload && strcmp((char*)msg->payload, "SELF_PING") == 0) {
-        XSAN_LOG_INFO("[CommTest] PING message received by handler from self!");
+    XSAN_LOG_INFO("[TestMsgHandler] Received msg from %s: Type %u, PayloadLen %u", peer_addr_str, msg->header.type, msg->header.payload_length);
+    if (msg->header.type == XSAN_MSG_TYPE_HEARTBEAT && msg->payload && strcmp((char*)msg->payload, "SELF_PING_PAYLOAD") == 0) {
+        XSAN_LOG_INFO("[CommTest] PING (HEARTBEAT) received by handler from self!");
         g_comm_test_controller.pong_received_or_ping_handled = true;
         g_comm_test_controller.test_finished_signal = true;
     }
     xsan_protocol_message_destroy(msg);
 }
-
 
 static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
     (void)arg1;
@@ -177,78 +188,117 @@ static void xsan_node_main_spdk_thread_start(void *arg1, int rc) {
     xsan_disk_manager_t *dm = NULL;
     xsan_volume_manager_t *vm = NULL;
 
-    XSAN_LOG_INFO("XSAN SPDK application thread started (rc: %d).", rc);
-    if (rc != 0) { goto app_stop_no_cleanup; }
+    XSAN_LOG_INFO("XSAN SPDK app thread started (rc: %d).", rc);
+    if (rc != 0) { XSAN_LOG_FATAL("SPDK framework init failed."); goto app_stop_sequence_start; }
 
-    if (xsan_bdev_subsystem_init() != XSAN_OK) { goto app_stop_no_cleanup; }
-    if (xsan_disk_manager_init(&dm) != XSAN_OK) { goto app_stop_bdev_fini_only; }
+    if (xsan_bdev_subsystem_init() != XSAN_OK) { XSAN_LOG_FATAL("Bdev subsystem init failed."); goto app_stop_sequence_start; }
+    if (xsan_disk_manager_init(&dm) != XSAN_OK) { XSAN_LOG_FATAL("Disk manager init failed."); goto app_stop_bdev_fini; }
     g_async_io_test_controller.dm = dm;
-    if (xsan_volume_manager_init(dm, &vm) != XSAN_OK) { goto app_stop_dm_fini; }
+    if (xsan_volume_manager_init(dm, &vm) != XSAN_OK) { XSAN_LOG_FATAL("Volume manager init failed."); goto app_stop_disk_mgr_fini; }
     g_async_io_test_controller.vm = vm;
 
-    const char *node_listen_ip = "0.0.0.0";
-    uint16_t node_listen_port = 7777;
+    const char *node_listen_ip = "0.0.0.0"; uint16_t node_listen_port = 7777;
     if (xsan_node_comm_init(node_listen_ip, node_listen_port, _xsan_node_test_message_handler, NULL) != XSAN_OK) {
-        goto app_stop_vm_fini;
+        XSAN_LOG_FATAL("Node communication init failed."); goto app_stop_vol_mgr_fini;
     }
 
-    if (xsan_disk_manager_scan_and_register_bdevs(dm) != XSAN_OK) { /* Log error, continue */ }
+    if (xsan_disk_manager_scan_and_register_bdevs(dm) != XSAN_OK) { /* Log error, continue for test */ }
 
-    xsan_disk_t **disks = NULL; int disk_count = 0;
-    xsan_disk_manager_get_all_disks(dm, &disks, &disk_count);
-    /* ... log disks ... */
-    if(disks) { XSAN_LOG_DEBUG("Found %d XSAN disks.", disk_count); }
+    xsan_disk_t **disks_list = NULL; int disk_count = 0;
+    xsan_disk_manager_get_all_disks(dm, &disks_list, &disk_count);
+    XSAN_LOG_INFO("=== XSAN Disks (Post-Init/Load & Scan) ===");
+    for (int i = 0; i < disk_count; ++i) {
+        char id_str[SPDK_UUID_STRING_LEN]; char bdev_id_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(id_str, sizeof(id_str), (struct spdk_uuid*)&disks_list[i]->id.data[0]);
+        spdk_uuid_fmt_lower(bdev_id_str, sizeof(bdev_id_str), (struct spdk_uuid*)&disks_list[i]->bdev_uuid.data[0]);
+        XSAN_LOG_INFO("  Disk[%d] ID: %s, BDev: %s, BDevUUID: %s, Size: %.2fG, State: %d", i, id_str, disks_list[i]->bdev_name, bdev_id_str, (double)disks_list[i]->capacity_bytes / (1024.0*1024*1024), disks_list[i]->state);
+    }
+
+    XSAN_LOG_INFO("=== XSAN Volumes (Post-Init/Load) ===");
+    xsan_volume_t **vols_list = NULL; int vol_count = 0;
+    xsan_volume_list_all(vm, &vols_list, &vol_count);
+    for(int i=0; i<vol_count; ++i) {
+        char vid_str[SPDK_UUID_STRING_LEN]; char gid_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(vid_str, sizeof(vid_str), (struct spdk_uuid*)&vols_list[i]->id.data[0]);
+        spdk_uuid_fmt_lower(gid_str, sizeof(gid_str), (struct spdk_uuid*)&vols_list[i]->source_group_id.data[0]);
+        XSAN_LOG_INFO("  Vol[%d] ID: %s, Name: %s, Size: %.2fG, FTT: %u, Reps: %u, Group: %s", i, vid_str, vols_list[i]->name, (double)vols_list[i]->size_bytes / (1024.0*1024*1024), vols_list[i]->FTT, vols_list[i]->actual_replica_count, gid_str);
+    }
+    if(vols_list) xsan_volume_manager_free_volume_pointer_list(vols_list);
 
 
-    // --- Comm Test Init ---
+    // --- Test Group & Volume Creation with FTT ---
+    xsan_group_id_t test_dg_id; memset(&test_dg_id, 0, sizeof(test_dg_id)); bool dg_created = false;
+    xsan_volume_id_t test_vol_id; memset(&test_vol_id, 0, sizeof(test_vol_id)); bool vol_created = false;
+    xsan_volume_t *vol_for_async_test = NULL; xsan_disk_t *disk_for_vol_group = NULL;
+
+    if (disk_count > 0 && disks_list) {
+        disk_for_vol_group = disks_list[0]; // Use first available disk for the test group
+        const char *dg_bdevs[] = {disk_for_vol_group->bdev_name};
+        if (xsan_disk_manager_find_disk_group_by_name(dm, "MetaTestDG") == NULL && /* only create if not loaded */
+            xsan_disk_manager_disk_group_create(dm, "MetaTestDG", XSAN_DISK_GROUP_TYPE_PASSSTHROUGH, dg_bdevs, 1, &test_dg_id) == XSAN_OK) {
+            dg_created = true; XSAN_LOG_INFO("Created 'MetaTestDG'.");
+        } else { XSAN_LOG_WARN("Could not create 'MetaTestDG' or it already exists."); if(!dg_created) test_dg_id = xsan_disk_manager_find_disk_group_by_name(dm, "MetaTestDG")->id; /* try to get existing */}
+    } else { XSAN_LOG_WARN("No disks to create 'MetaTestDG'.");}
+    if(disks_list) { xsan_disk_manager_free_disk_pointer_list(disks_list); disks_list = NULL; }
+
+
+    if (!spdk_uuid_is_null((struct spdk_uuid*)&test_dg_id.data[0])) { // If group exists or was created
+        uint32_t test_ftt = 0; // Test with FTT=0 (single replica) first for simplicity of async test target
+        uint64_t vol_s_mb = (disk_for_vol_group && disk_for_vol_group->capacity_bytes / (1024*1024) > 128) ? 128 : (disk_for_vol_group ? disk_for_vol_group->capacity_bytes / (1024*1024*2) : 64);
+        if(vol_s_mb < 16) vol_s_mb = 16; // Ensure some reasonable size
+        uint64_t vol_s_bytes = vol_s_mb * 1024 * 1024;
+        uint32_t vol_bs = 4096;
+        if(vol_s_bytes < vol_bs) vol_s_bytes = vol_bs;
+
+        if (xsan_volume_get_by_name(vm, "MetaTestVol") == NULL) { // Only create if not loaded
+             XSAN_LOG_INFO("Attempting to create volume 'MetaTestVol' (FTT=%u)...", test_ftt);
+            err = xsan_volume_create(vm, "MetaTestVol", vol_s_bytes, test_dg_id, vol_bs, false, test_ftt, &test_vol_id);
+            if (err == XSAN_OK) { vol_created = true; XSAN_LOG_INFO("Created 'MetaTestVol'."); }
+            else { XSAN_LOG_ERROR("Failed to create 'MetaTestVol': %s", xsan_error_string(err));}
+        } else {
+            XSAN_LOG_INFO("Volume 'MetaTestVol' seems to exist from metadata load.");
+            vol_for_async_test = xsan_volume_get_by_name(vm, "MetaTestVol");
+            if(vol_for_async_test) {
+                 memcpy(&test_vol_id, &vol_for_async_test->id, sizeof(xsan_volume_id_t));
+                 vol_created = true; // Treat as "created" for test flow
+            }
+        }
+    } else { XSAN_LOG_WARN("Skipping 'MetaTestVol' creation, 'MetaTestDG' not available.");}
+
+    vol_for_async_test = xsan_volume_get_by_id(vm, test_vol_id); // Get the definitive pointer
+    if (vol_created && vol_for_async_test) {
+        XSAN_LOG_INFO("Volume 'MetaTestVol' (FTT %u, Replicas %u) details after creation/load:", vol_for_async_test->FTT, vol_for_async_test->actual_replica_count);
+        for(uint32_t r=0; r < vol_for_async_test->actual_replica_count; ++r) {
+            char rn_id[SPDK_UUID_STRING_LEN]; spdk_uuid_fmt_lower(rn_id, sizeof(rn_id), (struct spdk_uuid*)&vol_for_async_test->replica_nodes[r].node_id.data[0]);
+            XSAN_LOG_INFO("  Replica[%u]: NodeID=%s, Addr=%s:%u", r, rn_id, vol_for_async_test->replica_nodes[r].node_ip_addr, vol_for_async_test->replica_nodes[r].node_comm_port);
+        }
+    }
+
+    // --- Start Tests (Comm Test first, then Async I/O Test) ---
     memset(&g_comm_test_controller, 0, sizeof(g_comm_test_controller));
-    XSAN_LOG_INFO("[CommTest] Attempting to connect to self (%s:%u) for PING test...", node_listen_ip, node_listen_port);
-    // Use 127.0.0.1 for self-connect even if listening on 0.0.0.0
+    memset(&g_async_io_test_controller, 0, sizeof(g_async_io_test_controller));
+    g_async_io_test_controller.dm = dm; g_async_io_test_controller.vm = vm; // Pass managers to async IO test
+
+    XSAN_LOG_INFO("[CommTest] Initiating self-connect PING test...");
     err = xsan_node_comm_connect("127.0.0.1", node_listen_port, _comm_test_connect_cb, &g_comm_test_controller);
-    if(err != XSAN_OK) {
-        XSAN_LOG_ERROR("[CommTest] Failed to initiate self-connect: %s", xsan_error_string(err));
-        g_comm_test_controller.test_finished_signal = true; // Mark as finished (failed)
-    }
+    if(err != XSAN_OK) { XSAN_LOG_ERROR("[CommTest] Failed to initiate self-connect: %s", xsan_error_string(err)); g_comm_test_controller.test_finished_signal = true; }
 
-
-    // --- Volume & Async I/O Test ---
-    xsan_group_id_t dg_id; memset(&dg_id, 0, sizeof(dg_id)); bool dg_created = false;
-    xsan_volume_id_t vol_id; memset(&vol_id, 0, sizeof(vol_id)); bool vol_created = false;
-    xsan_volume_t *vol_for_test = NULL; xsan_disk_t *disk_for_vol = NULL;
-
-    if (disk_count > 0 && disks) {
-        disk_for_vol = disks[0];
-        const char *dg_bdevs[] = {disk_for_vol->bdev_name};
-        if (xsan_disk_manager_disk_group_create(dm, "MetaTestDG", XSAN_DISK_GROUP_TYPE_PASSSTHROUGH, dg_bdevs, 1, &dg_id) == XSAN_OK) {
-            dg_created = true;
-            uint64_t v_size = (disk_for_vol->capacity_bytes / (1024*1024) > 128) ? (128*1024*1024) : disk_for_vol->capacity_bytes/2;
-            if (v_size < 4096) v_size = 4096;
-            if (xsan_volume_create(vm, "MetaTestVol", v_size, dg_id, 4096, false, &vol_id) == XSAN_OK) {
-                vol_created = true;
-                vol_for_test = xsan_volume_get_by_id(vm, vol_id);
-            } else { XSAN_LOG_ERROR("Failed to create MetaTestVol for async IO test.");}
-        } else { XSAN_LOG_ERROR("Failed to create MetaTestDG for async IO test.");}
-    }
-    if(disks) { xsan_disk_manager_free_disk_pointer_list(disks); disks = NULL; }
-
-
-    if (vol_created && vol_for_test && disk_for_vol) {
-        g_async_io_test_controller.test_finished_signal = false;
-        _start_async_io_test_on_volume(&g_async_io_test_controller, vol_for_test);
+    if (vol_created && vol_for_async_test && disk_for_vol_group) { // disk_for_vol_group is from DG creation
+        _start_async_io_test_on_volume(&g_async_io_test_controller, vol_for_async_test);
     } else {
-        XSAN_LOG_WARN("Skipping async I/O test as test volume setup failed.");
+        XSAN_LOG_WARN("Skipping async I/O test as test volume or its disk was not available.");
         g_async_io_test_controller.test_finished_signal = true;
     }
 
-    XSAN_LOG_INFO("Waiting for Async I/O and Comm tests to complete...");
+    XSAN_LOG_INFO("Waiting for all tests (Async I/O, Comm) to complete...");
     while(!g_async_io_test_controller.test_finished_signal || !g_comm_test_controller.test_finished_signal) {
         spdk_thread_poll(spdk_get_thread(), 0, 0);
     }
     XSAN_LOG_INFO("All tests signaled completion.");
 
     // --- Cleanup Test Entities ---
-    if (vol_created) { xsan_volume_delete(vm, vol_id); }
-    if (dg_created) { xsan_disk_manager_disk_group_delete(dm, dg_id); }
+    if (vol_created) { xsan_volume_delete(vm, test_vol_id); XSAN_LOG_INFO("Cleaned up 'MetaTestVol'.");}
+    if (dg_created) { xsan_disk_manager_disk_group_delete(dm, test_dg_id); XSAN_LOG_INFO("Cleaned up 'MetaTestDG'.");}
 
 app_stop_vm_fini:
     if (vm) xsan_volume_manager_fini(&vm);
@@ -262,11 +312,10 @@ app_stop_no_cleanup:
 }
 
 int main(int argc, char **argv) {
-    // ... (main function as before, ensuring xsan_node_comm_fini() is called before xsan_spdk_manager_app_fini()) ...
     xsan_log_config_t log_cfg = xsan_log_default_config();
     log_cfg.level = XSAN_LOG_LEVEL_DEBUG;
     xsan_log_init(&log_cfg);
-    XSAN_LOG_INFO("XSAN Node starting...");
+    XSAN_LOG_INFO("XSAN Node starting (main function)...");
     const char *spdk_json_conf_file = NULL;
     if (argc > 1) {
         for (int i = 1; i < argc; ++i) {
@@ -275,9 +324,8 @@ int main(int argc, char **argv) {
         }
     }
     if (spdk_json_conf_file) XSAN_LOG_INFO("Using SPDK JSON config: %s", spdk_json_conf_file);
-    else XSAN_LOG_WARN("No SPDK JSON config. Bdevs may not be available.");
+    else XSAN_LOG_WARN("No SPDK JSON config. Bdevs may not be available for tests.");
 
-    // Ensure meta DB dirs exist
     mkdir("./xsan_meta_db", 0755);
     mkdir("./xsan_meta_db/disk_manager_db", 0755);
     mkdir("./xsan_meta_db/volume_manager_db", 0755);
@@ -289,7 +337,7 @@ int main(int argc, char **argv) {
 
     xsan_node_comm_fini();
     xsan_spdk_manager_app_fini();
-    XSAN_LOG_INFO("XSAN Node shut down.");
+    XSAN_LOG_INFO("XSAN Node has shut down.");
     xsan_log_shutdown();
     return (err == XSAN_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/storage/volume_manager.c
+++ b/src/storage/volume_manager.c
@@ -48,26 +48,24 @@ static void _xsan_internal_volume_destroy_cb(void *volume_data) {
 xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *disk_manager, xsan_volume_manager_t **vm_instance_out) {
     const char *default_db_path_suffix = "xsan_meta_db/volume_manager";
     char actual_db_path[XSAN_MAX_PATH_LEN];
-    // TODO: Get base path from global config
     snprintf(actual_db_path, sizeof(actual_db_path), "./%s", default_db_path_suffix);
 
-    if (g_xsan_volume_manager_instance != NULL) { /* ... */ return XSAN_OK; }
-    if (!disk_manager) { /* ... */ return XSAN_ERROR_INVALID_PARAM; }
+    if (g_xsan_volume_manager_instance != NULL) { XSAN_LOG_WARN("XSAN Volume Manager already initialized."); if (vm_instance_out) *vm_instance_out = g_xsan_volume_manager_instance; return XSAN_OK; }
+    if (!disk_manager) { XSAN_LOG_ERROR("Disk Manager instance is required for Volume Manager."); if (vm_instance_out) *vm_instance_out = NULL; return XSAN_ERROR_INVALID_PARAM; }
 
     XSAN_LOG_INFO("Initializing XSAN Volume Manager (DB path: %s)...", actual_db_path);
     xsan_volume_manager_t *vm = (xsan_volume_manager_t *)XSAN_MALLOC(sizeof(xsan_volume_manager_t));
-    if (!vm) { /* ... */ return XSAN_ERROR_OUT_OF_MEMORY; }
+    if (!vm) { XSAN_LOG_ERROR("Failed to MALLOC Volume Manager."); if (vm_instance_out) *vm_instance_out = NULL; return XSAN_ERROR_OUT_OF_MEMORY; }
     memset(vm, 0, sizeof(xsan_volume_manager_t));
     xsan_strcpy_safe(vm->metadata_db_path, actual_db_path, XSAN_MAX_PATH_LEN);
 
     vm->managed_volumes = xsan_list_create(_xsan_internal_volume_destroy_cb);
-    if (!vm->managed_volumes) { /* ... cleanup ... */ XSAN_FREE(vm); return XSAN_ERROR_OUT_OF_MEMORY; }
-
-    if (pthread_mutex_init(&vm->lock, NULL) != 0) { /* ... cleanup ... */ return XSAN_ERROR_SYSTEM; }
+    if (!vm->managed_volumes) { XSAN_LOG_ERROR("Failed to create list for volumes."); XSAN_FREE(vm); if (vm_instance_out) *vm_instance_out = NULL; return XSAN_ERROR_OUT_OF_MEMORY; }
+    if (pthread_mutex_init(&vm->lock, NULL) != 0) { XSAN_LOG_ERROR("Mutex init failed for Volume Manager."); xsan_list_destroy(vm->managed_volumes); XSAN_FREE(vm); if (vm_instance_out) *vm_instance_out = NULL; return XSAN_ERROR_SYSTEM; }
 
     vm->disk_manager = disk_manager;
     vm->md_store = xsan_metadata_store_open(vm->metadata_db_path, true);
-    if (!vm->md_store) { /* ... cleanup ... */ return XSAN_ERROR_STORAGE_GENERIC; }
+    if (!vm->md_store) { XSAN_LOG_ERROR("Failed to open metadata store for Volume Manager: %s", vm->metadata_db_path); /* cleanup */ pthread_mutex_destroy(&vm->lock); xsan_list_destroy(vm->managed_volumes); XSAN_FREE(vm); if (vm_instance_out) *vm_instance_out = NULL; return XSAN_ERROR_STORAGE_GENERIC;}
 
     vm->initialized = true;
     g_xsan_volume_manager_instance = vm;
@@ -79,12 +77,8 @@ xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *disk_manager, xsan_vo
 }
 
 void xsan_volume_manager_fini(xsan_volume_manager_t **vm_ptr) {
-    // ... (Implementation as before, ensuring md_store is closed) ...
-    xsan_volume_manager_t *vm_to_fini = NULL;
-    if (vm_ptr && *vm_ptr) vm_to_fini = *vm_ptr;
-    else if (g_xsan_volume_manager_instance) vm_to_fini = g_xsan_volume_manager_instance;
-
-    if (!vm_to_fini || !vm_to_fini->initialized) { /* ... */ return; }
+    xsan_volume_manager_t *vm_to_fini = (vm_ptr && *vm_ptr) ? *vm_ptr : g_xsan_volume_manager_instance;
+    if (!vm_to_fini || !vm_to_fini->initialized) { /* Log already finalized */ if (vm_ptr) *vm_ptr = NULL; g_xsan_volume_manager_instance = NULL; return; }
     XSAN_LOG_INFO("Finalizing XSAN Volume Manager...");
     pthread_mutex_lock(&vm_to_fini->lock);
     xsan_list_destroy(vm_to_fini->managed_volumes); vm_to_fini->managed_volumes = NULL;
@@ -99,10 +93,10 @@ void xsan_volume_manager_fini(xsan_volume_manager_t **vm_ptr) {
 }
 
 static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char **json_string_out) {
-    // ... (Full implementation as sketched previously using json-c) ...
     if (!vol || !json_string_out) return XSAN_ERROR_INVALID_PARAM;
     json_object *jobj = json_object_new_object();
     char uuid_buf[SPDK_UUID_STRING_LEN];
+
     spdk_uuid_fmt_lower(uuid_buf, sizeof(uuid_buf), (const struct spdk_uuid *)&vol->id.data[0]);
     json_object_object_add(jobj, "id", json_object_new_string(uuid_buf));
     json_object_object_add(jobj, "name", json_object_new_string(vol->name));
@@ -114,6 +108,20 @@ static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char *
     json_object_object_add(jobj, "source_group_id", json_object_new_string(uuid_buf));
     json_object_object_add(jobj, "thin_provisioned", json_object_new_boolean(vol->thin_provisioned));
     json_object_object_add(jobj, "allocated_bytes", json_object_new_int64(vol->allocated_bytes));
+    json_object_object_add(jobj, "FTT", json_object_new_int(vol->FTT));
+    json_object_object_add(jobj, "actual_replica_count", json_object_new_int(vol->actual_replica_count));
+
+    json_object *jarray_replicas = json_object_new_array();
+    for (uint32_t i = 0; i < vol->actual_replica_count && i < XSAN_MAX_REPLICAS; ++i) {
+        json_object *jreplica = json_object_new_object();
+        spdk_uuid_fmt_lower(uuid_buf, sizeof(uuid_buf), (const struct spdk_uuid *)&vol->replica_nodes[i].node_id.data[0]);
+        json_object_object_add(jreplica, "node_id", json_object_new_string(uuid_buf));
+        json_object_object_add(jreplica, "node_ip_addr", json_object_new_string(vol->replica_nodes[i].node_ip_addr));
+        json_object_object_add(jreplica, "node_comm_port", json_object_new_int(vol->replica_nodes[i].node_comm_port));
+        json_object_array_add(jarray_replicas, jreplica);
+    }
+    json_object_object_add(jobj, "replica_nodes", jarray_replicas);
+
     const char *tmp_str = json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PLAIN);
     *json_string_out = xsan_strdup(tmp_str);
     json_object_put(jobj);
@@ -121,15 +129,16 @@ static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char *
 }
 
 static xsan_error_t _xsan_json_string_to_volume(const char *json_string, xsan_volume_manager_t *vm, xsan_volume_t **vol_out) {
-    // ... (Full implementation as sketched previously using json-c) ...
-    // (vm parameter is not strictly needed for this simple deserialization, but kept for consistency if future needs arise)
-    if (!json_string || !vol_out) return XSAN_ERROR_INVALID_PARAM;
+    if (!json_string || !vol_out) return XSAN_ERROR_INVALID_PARAM; // vm might not be needed if not resolving dependencies here
     struct json_object *jobj = json_tokener_parse(json_string);
     if (!jobj || is_error(jobj)) { XSAN_LOG_ERROR("Failed to parse JSON for volume: %s", json_string); if(jobj && !is_error(jobj)) json_object_put(jobj); return XSAN_ERROR_CONFIG_PARSE; }
+
     xsan_volume_t *vol = (xsan_volume_t *)XSAN_MALLOC(sizeof(xsan_volume_t));
     if (!vol) { json_object_put(jobj); return XSAN_ERROR_OUT_OF_MEMORY; }
     memset(vol, 0, sizeof(xsan_volume_t));
+
     struct json_object *val;
+    // ... (parse all basic fields as before) ...
     if (json_object_object_get_ex(jobj, "id", &val) && json_object_is_type(val, json_type_string)) spdk_uuid_parse((struct spdk_uuid*)&vol->id.data[0], json_object_get_string(val));
     if (json_object_object_get_ex(jobj, "name", &val) && json_object_is_type(val, json_type_string)) xsan_strcpy_safe(vol->name, json_object_get_string(val), XSAN_MAX_NAME_LEN);
     if (json_object_object_get_ex(jobj, "size_bytes", &val)) vol->size_bytes = (uint64_t)json_object_get_int64(val);
@@ -139,13 +148,33 @@ static xsan_error_t _xsan_json_string_to_volume(const char *json_string, xsan_vo
     if (json_object_object_get_ex(jobj, "source_group_id", &val) && json_object_is_type(val, json_type_string)) spdk_uuid_parse((struct spdk_uuid*)&vol->source_group_id.data[0], json_object_get_string(val));
     if (json_object_object_get_ex(jobj, "thin_provisioned", &val)) vol->thin_provisioned = json_object_get_boolean(val);
     if (json_object_object_get_ex(jobj, "allocated_bytes", &val)) vol->allocated_bytes = (uint64_t)json_object_get_int64(val);
+    if (json_object_object_get_ex(jobj, "FTT", &val)) vol->FTT = (uint32_t)json_object_get_int(val);
+    if (json_object_object_get_ex(jobj, "actual_replica_count", &val)) vol->actual_replica_count = (uint32_t)json_object_get_int(val);
+
+    struct json_object *jarray_replicas;
+    if (json_object_object_get_ex(jobj, "replica_nodes", &jarray_replicas) && json_object_is_type(jarray_replicas, json_type_array)) {
+        int array_len = json_object_array_length(jarray_replicas);
+        if ((uint32_t)array_len > XSAN_MAX_REPLICAS) array_len = XSAN_MAX_REPLICAS; // Cap at max
+        if ((uint32_t)array_len != vol->actual_replica_count) {
+            XSAN_LOG_WARN("Volume '%s' actual_replica_count (%u) mismatch with persisted replica_nodes array len (%d). Using array len.", vol->name, vol->actual_replica_count, array_len);
+            vol->actual_replica_count = array_len;
+        }
+        for (int i = 0; i < array_len; ++i) {
+            struct json_object *jreplica = json_object_array_get_idx(jarray_replicas, i);
+            if (jreplica && json_object_is_type(jreplica, json_type_object)) {
+                if (json_object_object_get_ex(jreplica, "node_id", &val) && json_object_is_type(val, json_type_string)) spdk_uuid_parse((struct spdk_uuid*)&vol->replica_nodes[i].node_id.data[0], json_object_get_string(val));
+                if (json_object_object_get_ex(jreplica, "node_ip_addr", &val) && json_object_is_type(val, json_type_string)) xsan_strcpy_safe(vol->replica_nodes[i].node_ip_addr, json_object_get_string(val), INET6_ADDRSTRLEN);
+                if (json_object_object_get_ex(jreplica, "node_comm_port", &val)) vol->replica_nodes[i].node_comm_port = (uint16_t)json_object_get_int(val);
+            }
+        }
+    }
+
     json_object_put(jobj);
     *vol_out = vol;
     return XSAN_OK;
 }
 
 static xsan_error_t xsan_volume_manager_save_volume_meta(xsan_volume_manager_t *vm, xsan_volume_t *vol) {
-    // ... (Implementation as sketched) ...
     if (!vm || !vol || !vm->md_store) return XSAN_ERROR_INVALID_PARAM;
     char key_buf[XSAN_MAX_NAME_LEN + SPDK_UUID_STRING_LEN];
     char vol_id_str[SPDK_UUID_STRING_LEN];
@@ -162,7 +191,6 @@ static xsan_error_t xsan_volume_manager_save_volume_meta(xsan_volume_manager_t *
 }
 
 static xsan_error_t xsan_volume_manager_delete_volume_meta(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id) {
-    // ... (Implementation as sketched) ...
     if (!vm || !vm->md_store) return XSAN_ERROR_INVALID_PARAM;
     char key_buf[XSAN_MAX_NAME_LEN + SPDK_UUID_STRING_LEN];
     char vol_id_str[SPDK_UUID_STRING_LEN];
@@ -175,7 +203,6 @@ static xsan_error_t xsan_volume_manager_delete_volume_meta(xsan_volume_manager_t
 }
 
 xsan_error_t xsan_volume_manager_load_metadata(xsan_volume_manager_t *vm) {
-    // ... (Implementation as sketched, using iterator and _xsan_json_string_to_volume) ...
     if (!vm || !vm->initialized || !vm->md_store) return XSAN_ERROR_INVALID_PARAM;
     XSAN_LOG_INFO("Loading volume metadata from RocksDB store: %s", vm->metadata_db_path);
     pthread_mutex_lock(&vm->lock);
@@ -210,32 +237,42 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
                                 xsan_group_id_t group_id,
                                 uint32_t logical_block_size_bytes,
                                 bool thin_provisioned,
+                                uint32_t ftt, // New FTT parameter
                                 xsan_volume_id_t *new_volume_id_out) {
-    // ... (Implementation as before, add calls to xsan_volume_manager_save_volume_meta on success) ...
     if (!vm || !vm->initialized || !name || size_bytes == 0 || logical_block_size_bytes == 0 ||
         (logical_block_size_bytes & (logical_block_size_bytes - 1)) != 0 ||
-        spdk_uuid_is_null((struct spdk_uuid*)&group_id.data[0])) {
+        spdk_uuid_is_null((struct spdk_uuid*)&group_id.data[0]) ||
+        (ftt + 1) > XSAN_MAX_REPLICAS ) {
+        XSAN_LOG_ERROR("Invalid parameters for volume create. FTT %u, MAX_REPLICAS %d", ftt, XSAN_MAX_REPLICAS);
         return XSAN_ERROR_INVALID_PARAM;
     }
     if ((size_bytes % logical_block_size_bytes) != 0) {
+        XSAN_LOG_ERROR("Volume size %lu B is not a multiple of logical block size %u B.", size_bytes, logical_block_size_bytes);
         return XSAN_ERROR_INVALID_PARAM;
     }
+
     pthread_mutex_lock(&vm->lock);
     xsan_error_t err = XSAN_OK;
-    // ... (checks for name conflict, group validation, capacity check as before) ...
+
     xsan_list_node_t *iter_node;
-    XSAN_LIST_FOREACH(vm->managed_volumes, iter_node) { /* ... check name ... */
-        if (strncmp(((xsan_volume_t*)xsan_list_node_get_value(iter_node))->name, name, XSAN_MAX_NAME_LEN) == 0) {
-             pthread_mutex_unlock(&vm->lock); return XSAN_ERROR_ALREADY_EXISTS; }
+    XSAN_LIST_FOREACH(vm->managed_volumes, iter_node) {
+        xsan_volume_t *vol_iter = (xsan_volume_t*)xsan_list_node_get_value(iter_node);
+        if (strncmp(vol_iter->name, name, XSAN_MAX_NAME_LEN) == 0) {
+             XSAN_LOG_WARN("Volume with name '%s' already exists.", name);
+             pthread_mutex_unlock(&vm->lock);
+             return XSAN_ERROR_ALREADY_EXISTS;
+        }
     }
+
     xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, group_id);
-    if (!group || group->state != XSAN_STORAGE_STATE_ONLINE) { /* ... error ... */ err = !group ? XSAN_ERROR_NOT_FOUND : XSAN_ERROR_RESOURCE_BUSY; goto create_cleanup_unlock; }
-    if (!thin_provisioned && size_bytes > group->usable_capacity_bytes) { /* ... error ... */ err = XSAN_ERROR_INSUFFICIENT_SPACE; goto create_cleanup_unlock; }
+    if (!group) { XSAN_LOG_ERROR("Disk group for volume '%s' not found.", name); err = XSAN_ERROR_NOT_FOUND; goto create_cleanup_unlock; }
+    if (group->state != XSAN_STORAGE_STATE_ONLINE) { XSAN_LOG_ERROR("Disk group '%s' not online for vol '%s'.", group->name, name); err = XSAN_ERROR_RESOURCE_BUSY; goto create_cleanup_unlock; }
+    if (!thin_provisioned && size_bytes > group->usable_capacity_bytes) { XSAN_LOG_ERROR("Insufficient space in group '%s' for vol '%s'.", group->name, name); err = XSAN_ERROR_INSUFFICIENT_SPACE; goto create_cleanup_unlock; }
 
     xsan_volume_t *new_volume = (xsan_volume_t *)XSAN_MALLOC(sizeof(xsan_volume_t));
     if (!new_volume) { err = XSAN_ERROR_OUT_OF_MEMORY; goto create_cleanup_unlock; }
-    // ... (populate new_volume as before) ...
     memset(new_volume, 0, sizeof(xsan_volume_t));
+
     spdk_uuid_generate((struct spdk_uuid *)&new_volume->id.data[0]);
     xsan_strcpy_safe(new_volume->name, name, XSAN_MAX_NAME_LEN);
     new_volume->size_bytes = size_bytes; new_volume->block_size_bytes = logical_block_size_bytes;
@@ -244,16 +281,43 @@ xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm,
     memcpy(&new_volume->source_group_id, &group_id, sizeof(xsan_group_id_t));
     new_volume->thin_provisioned = thin_provisioned;
     new_volume->allocated_bytes = thin_provisioned ? 0 : size_bytes;
+    new_volume->FTT = ftt;
+    new_volume->actual_replica_count = 0;
 
-    if (xsan_list_append(vm->managed_volumes, new_volume) == NULL) { /* ... error, free new_volume ... */ err = XSAN_ERROR_OUT_OF_MEMORY; XSAN_FREE(new_volume); goto create_cleanup_unlock; }
+    // Simplified Replica Node Assignment
+    // TODO: Replace with actual cluster node discovery and placement logic.
+    // For now, replica_nodes[0] is local (placeholder).
+    if (XSAN_MAX_REPLICAS > 0) { // Ensure array bounds
+        // Placeholder for self/local node_id and comm info
+        spdk_uuid_generate((struct spdk_uuid*)&new_volume->replica_nodes[0].node_id.data[0]); // Should be this node's actual ID
+        xsan_strcpy_safe(new_volume->replica_nodes[0].node_ip_addr, "127.0.0.1", INET6_ADDRSTRLEN); // This node's listen IP
+        new_volume->replica_nodes[0].node_comm_port = 7777; // This node's listen port
+        new_volume->actual_replica_count = 1;
+
+        XSAN_LOG_DEBUG("Volume '%s': Local replica [0] assigned to self (NodeID placeholder, Addr: %s:%u)",
+                       new_volume->name, new_volume->replica_nodes[0].node_ip_addr, new_volume->replica_nodes[0].node_comm_port);
+
+        uint32_t target_total_replicas = ftt + 1;
+        if (target_total_replicas > XSAN_MAX_REPLICAS) target_total_replicas = XSAN_MAX_REPLICAS;
+        for (uint32_t i = 1; i < target_total_replicas; ++i) {
+            XSAN_LOG_WARN("Volume '%s': Remote replica %u assignment is placeholder. Real node selection needed.", new_volume->name, i);
+            // In a real system, you'd pick other nodes from a cluster list.
+            // For now, leaving them zeroed or with dummy data.
+            // If actual_replica_count does not reach ftt+1, it indicates partial configuration.
+        }
+        if (new_volume->actual_replica_count < (ftt + 1) && ftt > 0) {
+             XSAN_LOG_WARN("Volume '%s': Configured with %u replicas, but FTT %u requires %u. Not enough remote nodes selected (placeholder).",
+                      new_volume->name, new_volume->actual_replica_count, ftt, ftt + 1);
+        }
+    }
+
+
+    if (xsan_list_append(vm->managed_volumes, new_volume) == NULL) { XSAN_LOG_ERROR("Failed to append new volume '%s'.", new_volume->name); XSAN_FREE(new_volume); err = XSAN_ERROR_OUT_OF_MEMORY; goto create_cleanup_unlock; }
     if (new_volume_id_out) memcpy(new_volume_id_out, &new_volume->id, sizeof(xsan_volume_id_t));
 
-    XSAN_LOG_INFO("Volume '%s' (ID: %s) created in memory.", new_volume->name, spdk_uuid_get_string((struct spdk_uuid*)&new_volume->id.data[0]));
-    err = xsan_volume_manager_save_volume_meta(vm, new_volume); // Persist
-    if(err != XSAN_OK) {
-        XSAN_LOG_ERROR("Failed to save metadata for new volume '%s'. Volume might be lost on restart.", new_volume->name);
-        // Decide on rollback strategy: remove from list? For now, it's in memory but not persisted.
-    }
+    XSAN_LOG_INFO("Volume '%s' (ID: %s) created in memory. FTT=%u, ActualReplicas=%u", new_volume->name, spdk_uuid_get_string((struct spdk_uuid*)&new_volume->id.data[0]), new_volume->FTT, new_volume->actual_replica_count);
+    err = xsan_volume_manager_save_volume_meta(vm, new_volume);
+    if(err != XSAN_OK) { XSAN_LOG_ERROR("Failed to save metadata for new volume '%s'.", new_volume->name); }
 
 create_cleanup_unlock:
     pthread_mutex_unlock(&vm->lock);
@@ -261,13 +325,12 @@ create_cleanup_unlock:
 }
 
 xsan_error_t xsan_volume_delete(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id) {
-    // ... (Implementation as before, add call to xsan_volume_manager_delete_volume_meta on success) ...
     if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) return XSAN_ERROR_INVALID_PARAM;
     pthread_mutex_lock(&vm->lock);
     xsan_error_t err = XSAN_ERROR_NOT_FOUND;
     xsan_list_node_t *list_node = xsan_list_get_head(vm->managed_volumes);
     xsan_volume_t *volume_to_delete = NULL;
-    while(list_node != NULL) { /* ... find volume ... */
+    while(list_node != NULL) {
         xsan_volume_t *current_volume = (xsan_volume_t *)xsan_list_node_get_value(list_node);
         if (spdk_uuid_compare((struct spdk_uuid*)&current_volume->id.data[0], (struct spdk_uuid*)&volume_id.data[0]) == 0) {
             volume_to_delete = current_volume; break;
@@ -275,21 +338,16 @@ xsan_error_t xsan_volume_delete(xsan_volume_manager_t *vm, xsan_volume_id_t volu
         list_node = xsan_list_node_next(list_node);
     }
     if (volume_to_delete) {
-        xsan_list_remove_node(vm->managed_volumes, list_node); // This calls the destructor which frees volume_to_delete
-        err = xsan_volume_manager_delete_volume_meta(vm, volume_id); // Persist deletion
-        if (err != XSAN_OK) {
-            XSAN_LOG_ERROR("Volume (ID: %s) deleted from memory, but failed to delete metadata. Metadata might be stale.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
-            // At this point, it's deleted from memory. The metadata delete failure is an issue for next load.
-        } else {
-             XSAN_LOG_INFO("Volume (ID: %s) and its metadata deleted successfully.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
-        }
-        err = XSAN_OK; // Overall deletion from memory was successful
-    } else { /* ... log not found ... */ }
+        xsan_list_remove_node(vm->managed_volumes, list_node);
+        err = xsan_volume_manager_delete_volume_meta(vm, volume_id);
+        if (err != XSAN_OK) { XSAN_LOG_ERROR("Volume (ID: %s) deleted from memory, but failed to delete metadata.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));}
+        else { XSAN_LOG_INFO("Volume (ID: %s) and its metadata deleted successfully.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));}
+        err = XSAN_OK;
+    } else { XSAN_LOG_WARN("Volume (ID: %s) not found for deletion.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0])); }
     pthread_mutex_unlock(&vm->lock);
     return err;
 }
 
-// Query functions (get_by_id, get_by_name, list_all) remain largely the same as they operate on in-memory lists.
 xsan_volume_t *xsan_volume_get_by_id(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id) { /* ... as before ... */
     if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) return NULL;
     pthread_mutex_lock(&vm->lock);
@@ -329,9 +387,12 @@ void xsan_volume_manager_free_volume_pointer_list(xsan_volume_t **volume_ptr_arr
     if (volume_ptr_array) XSAN_FREE(volume_ptr_array);
 }
 
-// LBA to PBA mapping function remains largely the same, but ensure it uses the up-to-date disk manager for lookups.
-xsan_error_t xsan_volume_map_lba_to_physical( /* ... signature ... */ ) { /* ... as before ... */
-    // (Implementation from previous step, no direct metadata calls here, relies on in-memory state)
+xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
+                                             xsan_volume_id_t volume_id,
+                                             uint64_t logical_block_idx,
+                                             xsan_disk_id_t *out_disk_id,
+                                             uint64_t *out_physical_block_idx,
+                                             uint32_t *out_physical_block_size) {
     if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])
         || !out_disk_id || !out_physical_block_idx || !out_physical_block_size) {
         return XSAN_ERROR_INVALID_PARAM;
@@ -340,24 +401,26 @@ xsan_error_t xsan_volume_map_lba_to_physical( /* ... signature ... */ ) { /* ...
     if (!vol) return XSAN_ERROR_NOT_FOUND;
     if (logical_block_idx >= vol->num_blocks) return XSAN_ERROR_OUT_OF_BOUNDS;
     xsan_disk_group_t *group = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, vol->source_group_id);
-    if (!group) { /* ... error ... */ return XSAN_ERROR_NOT_FOUND; }
-    if (group->disk_count == 0) { /* ... error ... */ return XSAN_ERROR_STORAGE_GENERIC; }
+    if (!group) { return XSAN_ERROR_NOT_FOUND; }
+    if (group->disk_count == 0) { return XSAN_ERROR_STORAGE_GENERIC; }
     xsan_disk_id_t target_disk_id_from_group;
-    memcpy(&target_disk_id_from_group, &group->disk_ids[0], sizeof(xsan_disk_id_t));
+    memcpy(&target_disk_id_from_group, &group->disk_ids[0], sizeof(xsan_disk_id_t)); // Simple: first disk
     xsan_disk_t *target_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, target_disk_id_from_group);
-    if (!target_disk) { /* ... error ... */ return XSAN_ERROR_NOT_FOUND; }
-    if (target_disk->block_size_bytes == 0) { /* ... error ... */ return XSAN_ERROR_STORAGE_GENERIC; }
+    if (!target_disk) { return XSAN_ERROR_NOT_FOUND; }
+    if (target_disk->block_size_bytes == 0) { return XSAN_ERROR_STORAGE_GENERIC; }
     *out_physical_block_size = target_disk->block_size_bytes;
     *out_physical_block_idx = (logical_block_idx * vol->block_size_bytes) / target_disk->block_size_bytes;
-    uint64_t num_physical_blocks_needed_for_logical_block = (vol->block_size_bytes + target_disk->block_size_bytes - 1) / target_disk->block_size_bytes;
-    if ((*out_physical_block_idx + num_physical_blocks_needed_for_logical_block -1) >= target_disk->num_blocks) { /* ... error ... */ return XSAN_ERROR_OUT_OF_BOUNDS; }
+    uint64_t num_phys_blks_for_log_blk = (vol->block_size_bytes + target_disk->block_size_bytes - 1) / target_disk->block_size_bytes;
+    if ((*out_physical_block_idx + num_phys_blks_for_log_blk -1) >= target_disk->num_blocks) { return XSAN_ERROR_OUT_OF_BOUNDS; }
     memcpy(out_disk_id, &target_disk->id, sizeof(xsan_disk_id_t));
     return XSAN_OK;
 }
 
-// Async I/O functions remain largely the same, they operate on in-memory structures.
-// The persistence is handled by create/delete.
-xsan_error_t _xsan_volume_submit_async_io( /* ... */) { /* ... as before ... */
+static xsan_error_t _xsan_volume_submit_async_io(
+    xsan_volume_manager_t *vm, xsan_volume_id_t volume_id, uint64_t logical_byte_offset,
+    uint64_t length_bytes, void *user_buf, bool is_read_op,
+    xsan_user_io_completion_cb_t user_cb, void *user_cb_arg) {
+    // ... (Implementation as before) ...
     if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0]) || !user_buf || length_bytes == 0 || !user_cb) return XSAN_ERROR_INVALID_PARAM;
     xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id);
     if (!vol) return XSAN_ERROR_NOT_FOUND;
@@ -371,15 +434,18 @@ xsan_error_t _xsan_volume_submit_async_io( /* ... */) { /* ... as before ... */
     xsan_disk_t *target_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, physical_disk_id);
     if (!target_disk) return XSAN_ERROR_NOT_FOUND;
     if (length_bytes % physical_bdev_block_size != 0) return XSAN_ERROR_INVALID_PARAM;
-    // uint32_t num_physical_blocks_for_io = length_bytes / physical_bdev_block_size; // Not directly used for io_req create
     xsan_io_request_t *io_req = xsan_io_request_create(volume_id, user_buf, physical_start_block_idx_on_disk * physical_bdev_block_size, length_bytes, physical_bdev_block_size, is_read_op, user_cb, user_cb_arg);
     if (!io_req) return XSAN_ERROR_OUT_OF_MEMORY;
     memcpy(&io_req->target_disk_id, &target_disk->id, sizeof(xsan_disk_id_t));
     xsan_strcpy_safe(io_req->target_bdev_name, target_disk->bdev_name, XSAN_MAX_NAME_LEN);
-    // io_req's offset_blocks and num_blocks are set by xsan_io_request_create based on physical params
+    io_req->bdev_desc = target_disk->bdev_descriptor; // Pass the opened descriptor
     xsan_error_t submit_err = xsan_io_submit_request_to_bdev(io_req);
-    if (submit_err != XSAN_OK) return submit_err; // submit_err frees io_req on failure
+    if (submit_err != XSAN_OK) return submit_err;
     return XSAN_OK;
 }
-xsan_error_t xsan_volume_read_async( /* ... */ ) { return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes, user_buf, true, user_cb, user_cb_arg); }
-xsan_error_t xsan_volume_write_async( /* ... */ ) { return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes, (void*)user_buf, false, user_cb, user_cb_arg); }
+xsan_error_t xsan_volume_read_async(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id, uint64_t logical_byte_offset, uint64_t length_bytes, void *user_buf, xsan_user_io_completion_cb_t user_cb, void *user_cb_arg) {
+    return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes, user_buf, true, user_cb, user_cb_arg);
+}
+xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id, uint64_t logical_byte_offset, uint64_t length_bytes, const void *user_buf, xsan_user_io_completion_cb_t user_cb, void *user_cb_arg) {
+    return _xsan_volume_submit_async_io(vm, volume_id, logical_byte_offset, length_bytes, (void*)user_buf, false, user_cb, user_cb_arg);
+}


### PR DESCRIPTION
- I updated `xsan_volume_t` in `xsan_storage.h` to include FTT (Failures To Tolerate), `actual_replica_count`, and an array of `xsan_replica_location_t` (`node_id`, `ip`, `port`) to store replica information.
- I modified `xsan_volume_create` in `volume_manager` to accept an FTT parameter and populate the new replication-related fields in `xsan_volume_t`. Initial local replica assignment uses placeholder node ID/comms info; remote replica assignment is stubbed.
- I updated JSON serialization (`_xsan_volume_to_json_string`) and deserialization (`_xsan_json_string_to_volume`) in `volume_manager.c` to save and load the new FTT and `replica_nodes` array to/from RocksDB.
- I enhanced the `xsan_node.c` test application to create volumes with an FTT value and log the persisted/loaded replication metadata, verifying its handling.