### PR TITLE
feat: Implement core volume management and replication foundations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ add_subdirectory(src/replication) # Added replication (for replicated IO context
 add_subdirectory(src/metadata) # Added metadata (for RocksDB store wrapper)
 add_subdirectory(src/storage) # Added storage (for disk_manager, volume_manager)
 add_subdirectory(src/vhost)   # Added vhost (for XSAN vbdev and vhost integration)
+add_subdirectory(src/nvmf)    # Added NVMe-oF target module
 add_subdirectory(src/main)    # Main executable likely defined here
 add_subdirectory(tests)
 

--- a/include/xsan_cluster.h
+++ b/include/xsan_cluster.h
@@ -115,4 +115,36 @@ xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
                                       char *ip_buf, size_t ip_buf_len,
                                       uint16_t *port_out);
 
+/**
+ * @brief Retrieves a list of all currently known cluster nodes.
+ * The primary source for this list is initially the seed nodes from configuration.
+ * The caller is responsible for freeing the allocated `nodes_array_out` using
+ * `xsan_cluster_free_known_nodes_array`.
+ *
+ * @param nodes_array_out Pointer to `xsan_node_t*`. On success, this will point to an
+ *                        allocated array of `xsan_node_t` structures.
+ * @param count_out Pointer to a size_t where the number of nodes in the array will be stored.
+ * @return XSAN_OK on success, XSAN_ERROR_NOT_INITIALIZED if cluster not ready,
+ *         XSAN_ERROR_OUT_OF_MEMORY on allocation failure.
+ */
+xsan_error_t xsan_cluster_get_all_known_nodes(xsan_node_t **nodes_array_out, size_t *count_out);
+
+/**
+ * @brief Frees the array of xsan_node_t structures allocated by xsan_cluster_get_all_known_nodes.
+ *
+ * @param nodes_array The array to free.
+ */
+void xsan_cluster_free_known_nodes_array(xsan_node_t *nodes_array);
+
+/**
+ * @brief Gets information for a specific known node by its XSAN Node ID.
+ *
+ * @param node_id The UUID of the node to find.
+ * @param node_info_out Pointer to an xsan_node_t structure to be filled with the node's information.
+ * @return XSAN_OK if the node is found, XSAN_ERROR_NOT_FOUND if not found,
+ *         XSAN_ERROR_NOT_INITIALIZED if cluster not ready.
+ */
+xsan_error_t xsan_cluster_get_node_by_id(xsan_node_id_t node_id, xsan_node_t *node_info_out);
+
+
 #endif /* XSAN_CLUSTER_H */

--- a/include/xsan_cluster.h
+++ b/include/xsan_cluster.h
@@ -100,4 +100,19 @@ bool xsan_cluster_is_master(void);
  */
 xsan_error_t xsan_cluster_get_master(xsan_uuid_t *master_id);
 
+/**
+ * @brief Retrieves the local node's essential information.
+ * This information is typically loaded from configuration at startup.
+ *
+ * @param node_id_out Pointer to store the local node's XSAN UUID.
+ * @param ip_buf Buffer to store the local node's IP address string.
+ * @param ip_buf_len Size of the ip_buf.
+ * @param port_out Pointer to store the local node's communication port.
+ * @return XSAN_OK on success, XSAN_ERROR_NOT_INITIALIZED if config not loaded,
+ *         or other error codes for invalid parameters/parsing issues.
+ */
+xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
+                                      char *ip_buf, size_t ip_buf_len,
+                                      uint16_t *port_out);
+
 #endif /* XSAN_CLUSTER_H */

--- a/src/cluster/CMakeLists.txt
+++ b/src/cluster/CMakeLists.txt
@@ -2,6 +2,7 @@
 # 集群管理模块 - 依赖 utils, common, network, storage 模块
 
 set(XSAN_CLUSTER_SOURCES
+    xsan_cluster.c # Added: Contains xsan_get_local_node_info and stubs
     node_discovery.c
     heartbeat.c
     node_manager.c

--- a/src/cluster/xsan_cluster.c
+++ b/src/cluster/xsan_cluster.c
@@ -1,15 +1,28 @@
 #include "xsan_cluster.h"
-#include "xsan_config.h" // For xsan_node_config_t
+#include "xsan_config.h" // For xsan_node_config_t, xsan_cluster_config_t
 #include "xsan_log.h"
 #include "xsan_string_utils.h" // For xsan_strcpy_safe
 #include "xsan_error.h"
-#include "spdk/uuid.h"   // For spdk_uuid_parse
+#include "xsan_memory.h"   // For XSAN_MALLOC, XSAN_FREE
+#include "xsan_types.h"    // For xsan_node_t
+#include "spdk/uuid.h"   // For spdk_uuid_parse, spdk_uuid_is_null, spdk_uuid_compare, spdk_uuid_get_string
 
-// Assumes g_local_node_config is defined and populated in xsan_node.c (or another main module)
-// This is a common way to access app-wide config, but consider passing config via init functions
-// for better modularity in the long run.
+#include <string.h>      // For memcpy, strlen
+#include <pthread.h>     // For pthread_mutex_t
+
+// Assumes g_local_node_config and g_cluster_config are defined and populated
+// in xsan_node.c (or another main module an linked appropriately)
 extern xsan_node_config_t g_local_node_config;
-extern xsan_config_t *g_xsan_config; // To check if config system itself is initialized
+extern xsan_cluster_config_t g_cluster_config;
+extern xsan_config_t *g_xsan_config;
+
+// Internal storage for known cluster nodes, populated from seed_nodes initially
+#define XSAN_INTERNAL_MAX_KNOWN_NODES XSAN_MAX_SEED_NODES
+static xsan_node_t g_known_cluster_nodes[XSAN_INTERNAL_MAX_KNOWN_NODES];
+static size_t g_known_node_count = 0;
+static bool g_cluster_initialized = false;
+static pthread_mutex_t g_known_nodes_lock = PTHREAD_MUTEX_INITIALIZER;
+
 
 xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
                                       char *ip_buf, size_t ip_buf_len,
@@ -18,33 +31,26 @@ xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
         return XSAN_ERROR_INVALID_PARAM;
     }
 
-    // Check if the global configuration has been loaded.
-    // A simple check could be if g_xsan_config is NULL or g_local_node_config.node_id is empty.
     if (!g_xsan_config || strlen(g_local_node_config.node_id) == 0) {
         XSAN_LOG_ERROR("Local node configuration not loaded or node_id is empty. Call config load first.");
         return XSAN_ERROR_NOT_INITIALIZED;
     }
 
-    // Parse the node_id string from config into UUID format
     if (spdk_uuid_parse((struct spdk_uuid *)node_id_out->data, g_local_node_config.node_id) != 0) {
         XSAN_LOG_ERROR("Failed to parse configured node_id '%s' as UUID.", g_local_node_config.node_id);
-        // Ensure node_id_out is zeroed on error to avoid returning garbage
         memset(node_id_out->data, 0, sizeof(node_id_out->data));
         return XSAN_ERROR_CONFIG_PARSE;
     }
 
-    // Copy IP address and port
     xsan_strcpy_safe(ip_buf, g_local_node_config.bind_address, ip_buf_len);
     *port_out = g_local_node_config.port;
 
-    // Basic validation of copied/parsed values
-    if (strlen(ip_buf) == 0) { // Check if IP is empty after copy
+    if (strlen(ip_buf) == 0) {
         XSAN_LOG_ERROR("Loaded local node IP address is empty.");
         return XSAN_ERROR_CONFIG_INVALID;
     }
-    if (*port_out == 0) { // Check if port is invalid (0 is typically not a valid service port)
-        XSAN_LOG_WARN("Loaded local node port is 0. This might be unintentional.");
-        // Depending on requirements, this could be an error: return XSAN_ERROR_CONFIG_INVALID;
+    if (*port_out == 0 && strlen(ip_buf) > 0) { // Only warn if IP is set but port is 0
+        XSAN_LOG_WARN("Loaded local node port is 0 for IP %s. This might be unintentional.", ip_buf);
     }
 
     char uuid_str[SPDK_UUID_STRING_LEN];
@@ -55,24 +61,122 @@ xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
     return XSAN_OK;
 }
 
-// Stub implementations for other functions declared in xsan_cluster.h
-// These would be filled out as cluster management features are developed.
-
 xsan_error_t xsan_cluster_init(const char *config_path) {
-    XSAN_LOG_INFO("xsan_cluster_init called (config_path: %s) - STUB", config_path ? config_path : "None");
-    // TODO:
-    // 1. Load cluster-specific parts of the configuration (e.g., seed nodes)
-    //    using g_xsan_config and xsan_config_load_cluster_config(&g_cluster_config).
-    // 2. Initialize internal data structures for managing cluster nodes.
-    // 3. Potentially start discovery mechanisms or try to connect to seed nodes.
+    (void)config_path; // Assuming g_cluster_config is already populated from g_xsan_config
+
+    if (g_cluster_initialized) {
+        XSAN_LOG_WARN("XSAN Cluster module already initialized.");
+        return XSAN_OK;
+    }
+    if (!g_xsan_config || strlen(g_cluster_config.cluster_name) == 0) {
+         XSAN_LOG_ERROR("Global config (g_xsan_config) not loaded or cluster_config not populated (cluster_name is empty). Cannot initialize cluster module.");
+         return XSAN_ERROR_NOT_INITIALIZED;
+    }
+
+    XSAN_LOG_INFO("Initializing XSAN Cluster module with cluster name: %s", g_cluster_config.cluster_name);
+
+    pthread_mutex_lock(&g_known_nodes_lock);
+    g_known_node_count = 0;
+    for (size_t i = 0; i < g_cluster_config.seed_node_count && i < XSAN_INTERNAL_MAX_KNOWN_NODES; ++i) {
+        if (spdk_uuid_is_null((struct spdk_uuid*)&g_cluster_config.seed_nodes[i].id.data[0])) {
+            XSAN_LOG_WARN("Seed node at index %zu has a NULL UUID. Skipping.", i);
+            continue;
+        }
+        // Assuming storage_addr is the primary communication address for replicas
+        if (strlen(g_cluster_config.seed_nodes[i].storage_addr.ip) == 0 || g_cluster_config.seed_nodes[i].storage_addr.port == 0) {
+             XSAN_LOG_WARN("Seed node at index %zu (ID: %s) has invalid storage IP or port. Skipping.", i, spdk_uuid_get_string((struct spdk_uuid*)&g_cluster_config.seed_nodes[i].id.data[0]));
+            continue;
+        }
+
+        memcpy(&g_known_cluster_nodes[g_known_node_count], &g_cluster_config.seed_nodes[i], sizeof(xsan_node_t));
+
+        char uuid_str[SPDK_UUID_STRING_LEN];
+        spdk_uuid_fmt_lower(uuid_str, sizeof(uuid_str), (struct spdk_uuid*)&g_known_cluster_nodes[g_known_node_count].id.data[0]);
+        XSAN_LOG_INFO("Added known node from seed config: ID=%s, Hostname/IP=%s, StoragePort=%u",
+                       uuid_str,
+                       g_known_cluster_nodes[g_known_node_count].storage_addr.ip,
+                       g_known_cluster_nodes[g_known_node_count].storage_addr.port);
+        g_known_node_count++;
+    }
+    pthread_mutex_unlock(&g_known_nodes_lock);
+
+    g_cluster_initialized = true;
+    XSAN_LOG_INFO("XSAN Cluster module initialized with %zu known seed nodes.", g_known_node_count);
     return XSAN_OK;
 }
 
 void xsan_cluster_shutdown(void) {
-    XSAN_LOG_INFO("xsan_cluster_shutdown called - STUB");
-    // TODO: Clean up cluster resources, stop any cluster-related services (heartbeat, discovery).
+    if (!g_cluster_initialized) {
+        XSAN_LOG_DEBUG("XSAN Cluster module shutdown called but not initialized or already shut down.");
+        return;
+    }
+    XSAN_LOG_INFO("Shutting down XSAN Cluster module...");
+    pthread_mutex_lock(&g_known_nodes_lock);
+    g_known_node_count = 0;
+    pthread_mutex_unlock(&g_known_nodes_lock);
+    g_cluster_initialized = false;
+    XSAN_LOG_INFO("XSAN Cluster module shut down.");
 }
 
+xsan_error_t xsan_cluster_get_all_known_nodes(xsan_node_t **nodes_array_out, size_t *count_out) {
+    if (!nodes_array_out || !count_out) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    if (!g_cluster_initialized) {
+        XSAN_LOG_WARN("xsan_cluster_get_all_known_nodes called before cluster init or after shutdown.");
+        *nodes_array_out = NULL;
+        *count_out = 0;
+        return XSAN_ERROR_NOT_INITIALIZED;
+    }
+
+    pthread_mutex_lock(&g_known_nodes_lock);
+    if (g_known_node_count == 0) {
+        *nodes_array_out = NULL;
+        *count_out = 0;
+        pthread_mutex_unlock(&g_known_nodes_lock);
+        return XSAN_OK;
+    }
+
+    *nodes_array_out = (xsan_node_t *)XSAN_MALLOC(sizeof(xsan_node_t) * g_known_node_count);
+    if (!*nodes_array_out) {
+        *count_out = 0;
+        pthread_mutex_unlock(&g_known_nodes_lock);
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+
+    memcpy(*nodes_array_out, g_known_cluster_nodes, sizeof(xsan_node_t) * g_known_node_count);
+    *count_out = g_known_node_count;
+    pthread_mutex_unlock(&g_known_nodes_lock);
+
+    return XSAN_OK;
+}
+
+void xsan_cluster_free_known_nodes_array(xsan_node_t *nodes_array) {
+    if (nodes_array) {
+        XSAN_FREE(nodes_array);
+    }
+}
+
+xsan_error_t xsan_cluster_get_node_by_id(xsan_node_id_t node_id, xsan_node_t *node_info_out) {
+    if (!node_info_out || spdk_uuid_is_null((struct spdk_uuid*)&node_id.data[0])) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+     if (!g_cluster_initialized) {
+        return XSAN_ERROR_NOT_INITIALIZED;
+    }
+    pthread_mutex_lock(&g_known_nodes_lock);
+    for (size_t i = 0; i < g_known_node_count; ++i) {
+        if (spdk_uuid_compare((struct spdk_uuid*)&g_known_cluster_nodes[i].id.data[0], (struct spdk_uuid*)&node_id.data[0]) == 0) {
+            memcpy(node_info_out, &g_known_cluster_nodes[i], sizeof(xsan_node_t));
+            pthread_mutex_unlock(&g_known_nodes_lock);
+            return XSAN_OK;
+        }
+    }
+    pthread_mutex_unlock(&g_known_nodes_lock);
+    return XSAN_ERROR_NOT_FOUND;
+}
+
+// Stub implementations for other functions declared in xsan_cluster.h
 xsan_error_t xsan_cluster_join_node(const xsan_node_t *node_info) {
     (void)node_info;
     XSAN_LOG_INFO("xsan_cluster_join_node called - STUB");
@@ -87,28 +191,32 @@ xsan_error_t xsan_cluster_remove_node(xsan_uuid_t node_id, bool force) {
 }
 
 xsan_error_t xsan_cluster_get_info(xsan_cluster_t *cluster_info) {
-    (void)cluster_info;
+    (void)cluster_info; // This parameter is xsan_cluster_t from xsan_types.h, not xsan_cluster_config_t
     XSAN_LOG_INFO("xsan_cluster_get_info called - STUB");
+    // TODO: Populate cluster_info with runtime cluster state if needed.
+    // For now, it might copy data from g_cluster_config or g_known_cluster_nodes.
     return XSAN_ERROR_NOT_IMPLEMENTED;
 }
 
+// Note: xsan_cluster_get_node is similar to xsan_cluster_get_node_by_id,
+// but xsan_types.h defines xsan_node_t which is more detailed than just config.
+// The current xsan_cluster_get_node_by_id returns the configured/seed node info.
 xsan_error_t xsan_cluster_get_node(xsan_uuid_t node_id, xsan_node_t *node_info) {
-    (void)node_id;
-    (void)node_info;
-    XSAN_LOG_INFO("xsan_cluster_get_node called - STUB");
-    return XSAN_ERROR_NOT_IMPLEMENTED;
+    return xsan_cluster_get_node_by_id(node_id, node_info); // Delegate for now
 }
 
 xsan_error_t xsan_cluster_update_node_state(xsan_uuid_t node_id, xsan_node_state_t new_state) {
     (void)node_id;
     (void)new_state;
     XSAN_LOG_INFO("xsan_cluster_update_node_state called - STUB");
+    // TODO: Update the state of a node in g_known_cluster_nodes (if found)
+    // and potentially trigger events or re-evaluate cluster health.
     return XSAN_ERROR_NOT_IMPLEMENTED;
 }
 
 xsan_error_t xsan_cluster_health_check(void) {
     XSAN_LOG_INFO("xsan_cluster_health_check called - STUB");
-    return XSAN_OK; // Assume healthy for now
+    return XSAN_OK;
 }
 
 xsan_error_t xsan_cluster_start_heartbeat(uint32_t interval_seconds) {
@@ -135,15 +243,14 @@ xsan_error_t xsan_cluster_elect_master(void) {
 
 bool xsan_cluster_is_master(void) {
     XSAN_LOG_INFO("xsan_cluster_is_master called - STUB - returning true for now");
-    return true; // Placeholder
+    return true;
 }
 
 xsan_error_t xsan_cluster_get_master(xsan_uuid_t *master_id) {
-    (void)master_id;
+    if (!master_id) return XSAN_ERROR_INVALID_PARAM;
     XSAN_LOG_INFO("xsan_cluster_get_master called - STUB");
     // For placeholder, could copy local node ID if is_master is true
-    if (master_id) {
-         // xsan_get_local_node_info(master_id, NULL, 0, NULL); // Simplified, only gets ID
-    }
-    return XSAN_ERROR_NOT_IMPLEMENTED;
+    char ip_buf[INET6_ADDRSTRLEN];
+    uint16_t port;
+    return xsan_get_local_node_info(master_id, ip_buf, sizeof(ip_buf), &port); // Return local as master for now
 }

--- a/src/cluster/xsan_cluster.c
+++ b/src/cluster/xsan_cluster.c
@@ -1,0 +1,149 @@
+#include "xsan_cluster.h"
+#include "xsan_config.h" // For xsan_node_config_t
+#include "xsan_log.h"
+#include "xsan_string_utils.h" // For xsan_strcpy_safe
+#include "xsan_error.h"
+#include "spdk/uuid.h"   // For spdk_uuid_parse
+
+// Assumes g_local_node_config is defined and populated in xsan_node.c (or another main module)
+// This is a common way to access app-wide config, but consider passing config via init functions
+// for better modularity in the long run.
+extern xsan_node_config_t g_local_node_config;
+extern xsan_config_t *g_xsan_config; // To check if config system itself is initialized
+
+xsan_error_t xsan_get_local_node_info(xsan_node_id_t *node_id_out,
+                                      char *ip_buf, size_t ip_buf_len,
+                                      uint16_t *port_out) {
+    if (!node_id_out || !ip_buf || ip_buf_len == 0 || !port_out) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    // Check if the global configuration has been loaded.
+    // A simple check could be if g_xsan_config is NULL or g_local_node_config.node_id is empty.
+    if (!g_xsan_config || strlen(g_local_node_config.node_id) == 0) {
+        XSAN_LOG_ERROR("Local node configuration not loaded or node_id is empty. Call config load first.");
+        return XSAN_ERROR_NOT_INITIALIZED;
+    }
+
+    // Parse the node_id string from config into UUID format
+    if (spdk_uuid_parse((struct spdk_uuid *)node_id_out->data, g_local_node_config.node_id) != 0) {
+        XSAN_LOG_ERROR("Failed to parse configured node_id '%s' as UUID.", g_local_node_config.node_id);
+        // Ensure node_id_out is zeroed on error to avoid returning garbage
+        memset(node_id_out->data, 0, sizeof(node_id_out->data));
+        return XSAN_ERROR_CONFIG_PARSE;
+    }
+
+    // Copy IP address and port
+    xsan_strcpy_safe(ip_buf, g_local_node_config.bind_address, ip_buf_len);
+    *port_out = g_local_node_config.port;
+
+    // Basic validation of copied/parsed values
+    if (strlen(ip_buf) == 0) { // Check if IP is empty after copy
+        XSAN_LOG_ERROR("Loaded local node IP address is empty.");
+        return XSAN_ERROR_CONFIG_INVALID;
+    }
+    if (*port_out == 0) { // Check if port is invalid (0 is typically not a valid service port)
+        XSAN_LOG_WARN("Loaded local node port is 0. This might be unintentional.");
+        // Depending on requirements, this could be an error: return XSAN_ERROR_CONFIG_INVALID;
+    }
+
+    char uuid_str[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(uuid_str, sizeof(uuid_str), (struct spdk_uuid*)node_id_out->data);
+    XSAN_LOG_DEBUG("Retrieved local node info: ID=%s, IP=%s, Port=%u",
+                   uuid_str, ip_buf, *port_out);
+
+    return XSAN_OK;
+}
+
+// Stub implementations for other functions declared in xsan_cluster.h
+// These would be filled out as cluster management features are developed.
+
+xsan_error_t xsan_cluster_init(const char *config_path) {
+    XSAN_LOG_INFO("xsan_cluster_init called (config_path: %s) - STUB", config_path ? config_path : "None");
+    // TODO:
+    // 1. Load cluster-specific parts of the configuration (e.g., seed nodes)
+    //    using g_xsan_config and xsan_config_load_cluster_config(&g_cluster_config).
+    // 2. Initialize internal data structures for managing cluster nodes.
+    // 3. Potentially start discovery mechanisms or try to connect to seed nodes.
+    return XSAN_OK;
+}
+
+void xsan_cluster_shutdown(void) {
+    XSAN_LOG_INFO("xsan_cluster_shutdown called - STUB");
+    // TODO: Clean up cluster resources, stop any cluster-related services (heartbeat, discovery).
+}
+
+xsan_error_t xsan_cluster_join_node(const xsan_node_t *node_info) {
+    (void)node_info;
+    XSAN_LOG_INFO("xsan_cluster_join_node called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+xsan_error_t xsan_cluster_remove_node(xsan_uuid_t node_id, bool force) {
+    (void)node_id;
+    (void)force;
+    XSAN_LOG_INFO("xsan_cluster_remove_node called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+xsan_error_t xsan_cluster_get_info(xsan_cluster_t *cluster_info) {
+    (void)cluster_info;
+    XSAN_LOG_INFO("xsan_cluster_get_info called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+xsan_error_t xsan_cluster_get_node(xsan_uuid_t node_id, xsan_node_t *node_info) {
+    (void)node_id;
+    (void)node_info;
+    XSAN_LOG_INFO("xsan_cluster_get_node called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+xsan_error_t xsan_cluster_update_node_state(xsan_uuid_t node_id, xsan_node_state_t new_state) {
+    (void)node_id;
+    (void)new_state;
+    XSAN_LOG_INFO("xsan_cluster_update_node_state called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+xsan_error_t xsan_cluster_health_check(void) {
+    XSAN_LOG_INFO("xsan_cluster_health_check called - STUB");
+    return XSAN_OK; // Assume healthy for now
+}
+
+xsan_error_t xsan_cluster_start_heartbeat(uint32_t interval_seconds) {
+    (void)interval_seconds;
+    XSAN_LOG_INFO("xsan_cluster_start_heartbeat called - STUB");
+    return XSAN_OK;
+}
+
+void xsan_cluster_stop_heartbeat(void) {
+    XSAN_LOG_INFO("xsan_cluster_stop_heartbeat called - STUB");
+}
+
+xsan_error_t xsan_cluster_register_events(xsan_node_event_cb_t callback, void *user_data) {
+    (void)callback;
+    (void)user_data;
+    XSAN_LOG_INFO("xsan_cluster_register_events called - STUB");
+    return XSAN_OK;
+}
+
+xsan_error_t xsan_cluster_elect_master(void) {
+    XSAN_LOG_INFO("xsan_cluster_elect_master called - STUB");
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}
+
+bool xsan_cluster_is_master(void) {
+    XSAN_LOG_INFO("xsan_cluster_is_master called - STUB - returning true for now");
+    return true; // Placeholder
+}
+
+xsan_error_t xsan_cluster_get_master(xsan_uuid_t *master_id) {
+    (void)master_id;
+    XSAN_LOG_INFO("xsan_cluster_get_master called - STUB");
+    // For placeholder, could copy local node ID if is_master is true
+    if (master_id) {
+         // xsan_get_local_node_info(master_id, NULL, 0, NULL); // Simplified, only gets ID
+    }
+    return XSAN_ERROR_NOT_IMPLEMENTED;
+}

--- a/src/include/xsan_config.h
+++ b/src/include/xsan_config.h
@@ -63,6 +63,8 @@ typedef struct xsan_node_config {
     bool enable_ssl;                /* 是否启用SSL */
     char ssl_cert_file[256];        /* SSL证书文件 */
     char ssl_key_file[256];         /* SSL私钥文件 */
+    char nvmf_target_nqn[XSAN_MAX_NAME_LEN]; /* Optional NQN for NVMe-oF target */
+    char nvmf_listen_port[16];        /* Optional NVMe-oF listen port (as string) */
 } xsan_node_config_t;
 
 /* 存储配置 */

--- a/src/include/xsan_config.h
+++ b/src/include/xsan_config.h
@@ -79,10 +79,14 @@ typedef struct xsan_storage_config {
     bool enable_checksums;          /* 是否启用校验和 */
 } xsan_storage_config_t;
 
+#include "xsan_types.h" // For xsan_node_t, xsan_uuid_t
+
+#define XSAN_MAX_SEED_NODES 32 // Define max seed nodes for config
+
 /* 集群配置 */
 typedef struct xsan_cluster_config {
     char cluster_name[128];         /* 集群名称 */
-    char *seed_nodes[32];           /* 种子节点列表 */
+    xsan_node_t seed_nodes[XSAN_MAX_SEED_NODES]; /* 解析后的种子节点信息 */
     size_t seed_node_count;         /* 种子节点数量 */
     size_t min_nodes;               /* 最小节点数 */
     size_t max_nodes;               /* 最大节点数 */

--- a/src/include/xsan_disk_manager.h
+++ b/src/include/xsan_disk_manager.h
@@ -177,6 +177,55 @@ xsan_disk_group_t *xsan_disk_manager_find_disk_group_by_id(xsan_disk_manager_t *
 xsan_disk_group_t *xsan_disk_manager_find_disk_group_by_name(xsan_disk_manager_t *dm, const char *name);
 
 
+// --- Disk Group Space Allocation Operations ---
+
+/**
+ * @brief Allocates a set of physical extents from a disk group for a volume.
+ * This is a simplified initial implementation assuming mostly contiguous allocation
+ * or simple JBOD-like spanning.
+ *
+ * @param dm The disk manager instance.
+ * @param group_id ID of the disk group to allocate from.
+ * @param total_blocks_needed Total number of logical blocks the volume needs from this group
+ *                            (in terms of volume's logical block size).
+ * @param volume_logical_block_size The logical block size of the volume requesting space.
+ * @param extents_out Pointer to an array of xsan_volume_extent_mapping_t.
+ *                    On success, this will be allocated by the function and filled with
+ *                    the details of the allocated physical extents. The caller is responsible
+ *                    for freeing this array using XSAN_FREE().
+ * @param num_extents_out Pointer to store the number of extents in the allocated array.
+ * @return XSAN_OK on success.
+ *         XSAN_ERROR_INVALID_PARAM if inputs are invalid.
+ *         XSAN_ERROR_NOT_FOUND if the disk group is not found.
+ *         XSAN_ERROR_INSUFFICIENT_SPACE if the group doesn't have enough free space.
+ *         XSAN_ERROR_OUT_OF_MEMORY on memory allocation failure for extents_out.
+ */
+xsan_error_t xsan_disk_group_allocate_extents(xsan_disk_manager_t *dm,
+                                              xsan_group_id_t group_id,
+                                              uint64_t total_blocks_needed,
+                                              uint32_t volume_logical_block_size,
+                                              xsan_volume_extent_mapping_t **extents_out,
+                                              uint32_t *num_extents_out);
+
+/**
+ * @brief Frees a set of physical extents previously allocated to a volume from a disk group.
+ * This is a simplified initial implementation. True space reclamation for future reuse
+ * might be limited if not using a proper free space map (bitmap/freelist).
+ *
+ * @param dm The disk manager instance.
+ * @param group_id ID of the disk group from which space was allocated.
+ * @param extents Pointer to an array of xsan_volume_extent_mapping_t describing the extents to free.
+ * @param num_extents The number of extents in the array.
+ * @return XSAN_OK on success.
+ *         XSAN_ERROR_INVALID_PARAM if inputs are invalid.
+ *         XSAN_ERROR_NOT_FOUND if the disk group or specified physical disks within extents are not found.
+ */
+xsan_error_t xsan_disk_group_free_extents(xsan_disk_manager_t *dm,
+                                          xsan_group_id_t group_id,
+                                          const xsan_volume_extent_mapping_t *extents,
+                                          uint32_t num_extents);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/xsan_node_comm.h
+++ b/src/include/xsan_node_comm.h
@@ -35,6 +35,16 @@ typedef void (*xsan_node_message_handler_cb_t)(struct spdk_sock *sock,
                                                void *handler_cb_arg);
 
 /**
+ * @brief Callback for a specific message type, used with the registration mechanism.
+ * @param conn_ctx Context of the connection from which the message was received.
+ * @param msg The fully assembled message. Callee is responsible for destroying it.
+ * @param specific_cb_arg User-provided argument during handler registration.
+ */
+typedef void (*xsan_specific_message_handler_cb_t)(struct xsan_connection_ctx *conn_ctx, // Pass conn_ctx
+                                                   xsan_message_t *msg,
+                                                   void *specific_cb_arg);
+
+/**
  * @brief Callback invoked when a connection attempt (initiated by xsan_node_comm_connect) completes.
  *
  * @param sock The SPDK socket for the connection. This is valid and usable if status is 0 (success).
@@ -73,8 +83,22 @@ typedef void (*xsan_node_send_cb_t)(int status, void *send_cb_arg);
  * @return XSAN_OK on success, or an xsan_error_t code on failure.
  */
 xsan_error_t xsan_node_comm_init(const char *listen_ip, uint16_t listen_port,
-                                 xsan_node_message_handler_cb_t msg_handler_cb,
+                                 xsan_node_message_handler_cb_t msg_handler_cb, // This can be a generic dispatcher
                                  void *handler_cb_arg);
+
+/**
+ * @brief Registers a handler for a specific XSAN message type.
+ * If a handler is already registered for this type, it will be overwritten.
+ *
+ * @param type The message type to register a handler for.
+ * @param specific_handler The callback function to handle this message type.
+ * @param specific_cb_arg User-defined argument to be passed to the specific_handler.
+ * @return XSAN_OK on success, XSAN_ERROR_INVALID_PARAM if type is invalid or handler is NULL,
+ *         XSAN_ERROR_NOT_INITIALIZED if the comm module is not initialized.
+ */
+xsan_error_t xsan_node_comm_register_message_handler(xsan_message_type_t type,
+                                                     xsan_specific_message_handler_cb_t specific_handler,
+                                                     void *specific_cb_arg);
 
 /**
  * @brief Finalizes and cleans up the XSAN Node Communication module.

--- a/src/include/xsan_nvmf_target.h
+++ b/src/include/xsan_nvmf_target.h
@@ -1,0 +1,65 @@
+#ifndef XSAN_NVMF_TARGET_H
+#define XSAN_NVMF_TARGET_H
+
+#include "xsan_error.h"
+#include "xsan_types.h" // For xsan_volume_id_t (if needed in future public APIs)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initializes the XSAN NVMe-oF Target subsystem.
+ * This function should be called once from an SPDK reactor thread after
+ * SPDK has fully started and core XSAN modules (like volume manager for bdev access)
+ * are ready.
+ *
+ * It will create default NVMe-oF transports (e.g., TCP) and a default target.
+ *
+ * @param target_nqn The NQN for the default XSAN NVMe-oF Target Subsystem.
+ *                   If NULL, a default NQN might be generated or an error returned.
+ * @param listen_addr IP address for the NVMe-oF target to listen on (e.g., "0.0.0.0").
+ * @param listen_port Port number for the NVMe-oF target (e.g., 4420 for TCP).
+ * @return XSAN_OK on success, or an xsan_error_t code on failure.
+ */
+xsan_error_t xsan_nvmf_target_init(const char *target_nqn,
+                                   const char *listen_addr,
+                                   const char *listen_port_str); // Port as string for spdk_nvmf_transport_id
+
+/**
+ * @brief Finalizes and cleans up the XSAN NVMe-oF Target subsystem.
+ * Stops all subsystems, listeners, and destroys transports and the target.
+ * Must be called from an SPDK reactor thread during application shutdown.
+ */
+void xsan_nvmf_target_fini(void);
+
+/**
+ * @brief Makes an XSAN volume (represented by its backing SPDK bdev) available
+ *        as a namespace under the default NVMe-oF subsystem.
+ *
+ * @param bdev_name The name of the SPDK bdev that backs the XSAN volume.
+ * @param nsid The desired Namespace ID (NSID) for this namespace. If 0, SPDK might assign one.
+ *             It's generally better to assign a specific, unique NSID > 0.
+ * @param volume_uuid_str Optional: String representation of the XSAN volume UUID for the namespace. Can be NULL.
+ * @return XSAN_OK on success, or an xsan_error_t code on failure.
+ *         XSAN_ERROR_NOT_FOUND if the bdev_name does not correspond to a known SPDK bdev.
+ *         XSAN_ERROR_ALREADY_EXISTS if a namespace with the given NSID already exists (if nsid > 0).
+ */
+xsan_error_t xsan_nvmf_target_add_namespace(const char *bdev_name, uint32_t nsid, const char *volume_uuid_str);
+
+/**
+ * @brief Removes a namespace (previously added XSAN volume) from the default NVMe-oF subsystem.
+ *
+ * @param nsid The Namespace ID (NSID) of the namespace to remove.
+ * @return XSAN_OK on success, or XSAN_ERROR_NOT_FOUND if no namespace with the given NSID exists.
+ */
+xsan_error_t xsan_nvmf_target_remove_namespace(uint32_t nsid);
+
+// TODO: Add functions to create/delete/manage multiple NVMf subsystems if needed,
+//       rather than just a single default one.
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // XSAN_NVMF_TARGET_H

--- a/src/include/xsan_protocol.h
+++ b/src/include/xsan_protocol.h
@@ -235,6 +235,29 @@ xsan_message_t *xsan_protocol_message_create(xsan_message_type_t type,
  */
 void xsan_protocol_message_destroy(xsan_message_t *msg);
 
+/**
+ * @brief Creates a complete xsan_message_t, including a structured payload
+ *        and an optional additional raw data block.
+ * Initializes the header and sets its checksum field. The header's payload_length
+ * will be the sum of structured_payload_len and additional_data_len.
+ *
+ * @param type The message type.
+ * @param transaction_id The transaction ID.
+ * @param structured_payload Pointer to the structured payload data (e.g., a request struct). Can be NULL if structured_payload_len is 0.
+ * @param structured_payload_len Length of the structured payload data.
+ * @param additional_data Pointer to the additional raw data block (e.g., disk block data). Can be NULL if additional_data_len is 0.
+ * @param additional_data_len Length of the additional raw data block.
+ * @return A pointer to the newly created xsan_message_t, or NULL on failure.
+ *         The returned message must be freed using xsan_protocol_message_destroy.
+ */
+xsan_message_t *xsan_protocol_message_create_with_data(
+    xsan_message_type_t type,
+    uint64_t transaction_id,
+    const void *structured_payload,
+    uint32_t structured_payload_len,
+    const void *additional_data,
+    uint32_t additional_data_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/xsan_replication.h
+++ b/src/include/xsan_replication.h
@@ -65,6 +65,22 @@ typedef struct xsan_replicated_io_ctx {
 
 
 /**
+ * @brief Context for a single operation targeted at one specific (usually remote) replica.
+ * This is used by both replicated writes (for each remote replica) and by the read coordinator
+ * (for the current remote read attempt).
+ */
+typedef struct xsan_per_replica_op_ctx {
+    void *parent_rep_ctx;                      ///< Pointer to the parent context (e.g., xsan_replicated_io_ctx_t or xsan_replica_read_coordinator_ctx_t)
+    xsan_replica_location_t replica_location_info; ///< Information about the target replica node
+    struct xsan_message *request_msg_to_send;  ///< The protocol message to send to the replica
+    struct spdk_sock *connected_sock;          ///< Socket, if connection is established and reused
+    // Add any other state needed for this specific per-replica operation,
+    // e.g., retry count for this specific replica, timeout timer.
+    // uint32_t current_attempt_retries;
+} xsan_per_replica_op_ctx_t;
+
+
+/**
  * @brief Context for coordinating a read operation that might try multiple replicas.
  */
 typedef struct xsan_replica_read_coordinator_ctx {

--- a/src/include/xsan_volume_manager.h
+++ b/src/include/xsan_volume_manager.h
@@ -187,6 +187,36 @@ xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm,
                                      void *user_cb_arg);
 
 
+// --- Replica Request Handlers (to be called by node_comm dispatcher) ---
+
+/**
+ * @brief Handles an incoming XSAN_MSG_TYPE_REPLICA_WRITE_BLOCK_REQ message.
+ * This function is expected to be registered with the xsan_node_comm module.
+ * It processes the write request, performs the local write, and sends a response.
+ *
+ * @param conn_ctx The connection context from which the message was received.
+ *                 Can be used to send a response via conn_ctx->sock.
+ * @param msg The received xsan_message_t. The handler is responsible for destroying it.
+ * @param cb_arg_vol_mgr The xsan_volume_manager_t instance, passed during handler registration.
+ */
+void xsan_volume_manager_handle_replica_write_req(struct xsan_connection_ctx *conn_ctx,
+                                                  xsan_message_t *msg,
+                                                  void *cb_arg_vol_mgr);
+
+/**
+ * @brief Handles an incoming XSAN_MSG_TYPE_REPLICA_READ_BLOCK_REQ message.
+ * This function is expected to be registered with the xsan_node_comm module.
+ * It processes the read request, performs the local read, and sends a response with data.
+ *
+ * @param conn_ctx The connection context.
+ * @param msg The received xsan_message_t. The handler is responsible for destroying it.
+ * @param cb_arg_vol_mgr The xsan_volume_manager_t instance.
+ */
+void xsan_volume_manager_handle_replica_read_req(struct xsan_connection_ctx *conn_ctx,
+                                                 xsan_message_t *msg,
+                                                 void *cb_arg_vol_mgr);
+
+
 // Potentially add functions for resizing volumes, snapshots, etc. in the future.
 
 #ifdef __cplusplus

--- a/src/main/xsan_node.c
+++ b/src/main/xsan_node.c
@@ -6,46 +6,40 @@
 #include "xsan_volume_manager.h"
 #include "xsan_io.h"
 #include "xsan_node_comm.h"
-#include "xsan_vhost.h"
+#include "xsan_vhost.h" // Included, though not actively used in current E2E test
 #include "xsan_error.h"
 #include "xsan_string_utils.h"
-#include "xsan_cluster.h" // For xsan_get_local_node_info (will be called from volume_manager)
+#include "xsan_cluster.h"
+#include "xsan_nvmf_target.h"
+#include "xsan_metadata_store.h" // For md_store access in e2e test
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <unistd.h> // For sleep, usleep
 #include <sys/stat.h>
 #include <errno.h>
-#include <getopt.h> // For command line argument parsing
+#include <getopt.h>
 
 #include "spdk/uuid.h"
 #include "spdk/env.h"
 #include "spdk/sock.h"
 #include "spdk/thread.h"
 
-// Global config instances, accessible by other modules via extern (if needed) or access functions
+// Global config instances
 xsan_config_t *g_xsan_config = NULL;
 xsan_node_config_t g_local_node_config;
-xsan_cluster_config_t g_cluster_config; // If cluster config is also needed globally
-// xsan_node_id_t g_local_xsan_node_id; // Parsed UUID of local node
+xsan_cluster_config_t g_cluster_config;
+static char *g_xsan_config_file = NULL;
 
-#define XSAN_VHOST_SOCKET_DIR "/var/tmp/xsan_vhost_sockets"
-#define XSAN_TEST_VHOST_CTRLR_NAME "xsc0"
-#define XSAN_TEST_VBDEV_NAME_BASE "xnvb_MetaTestVolRep"
-
-
+// Test-related globals (from previous state, might be refactored/removed later)
 static bool g_simulate_replica_local_write_failure = false;
-// static uint64_t g_target_failure_tid_for_replica_write = 0; // Not used currently
-
 typedef enum {
-    ASYNC_IO_TEST_PHASE_IDLE,
-    ASYNC_IO_TEST_PHASE_WRITE1_SUBMITTED, ASYNC_IO_TEST_PHASE_READ1_SUBMITTED, ASYNC_IO_TEST_PHASE_VERIFY1_DONE,
-    ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED, ASYNC_IO_TEST_PHASE_READ2_AFTER_FAILED_REPLICA_SUBMITTED, ASYNC_IO_TEST_PHASE_VERIFY2_DONE,
-    ASYNC_IO_TEST_PHASE_ALL_COMPLETED,
-    ASYNC_IO_TEST_PHASE_FAILED
+    ASYNC_IO_TEST_PHASE_IDLE, ASYNC_IO_TEST_PHASE_WRITE1_SUBMITTED, ASYNC_IO_TEST_PHASE_READ1_SUBMITTED,
+    ASYNC_IO_TEST_PHASE_VERIFY1_DONE, ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED,
+    ASYNC_IO_TEST_PHASE_READ2_AFTER_FAILED_REPLICA_SUBMITTED, ASYNC_IO_TEST_PHASE_VERIFY2_DONE,
+    ASYNC_IO_TEST_PHASE_ALL_COMPLETED, ASYNC_IO_TEST_PHASE_FAILED
 } xsan_async_io_test_phase_t;
-
 typedef struct {
     xsan_volume_manager_t *vm; xsan_disk_manager_t *dm; xsan_volume_id_t volume_id_to_test;
     char target_bdev_name_for_log[XSAN_MAX_NAME_LEN]; uint32_t io_block_size; size_t dma_alignment;
@@ -54,22 +48,21 @@ typedef struct {
 } xsan_async_io_test_control_t;
 static xsan_async_io_test_control_t g_async_io_test_controller;
 
+// Forward declaration for E2E test function and its helpers
+static void _run_e2e_core_logic_tests(xsan_disk_manager_t *dm, xsan_volume_manager_t *vm);
 typedef struct {
-    struct spdk_sock *client_sock_to_self; bool connected_to_self; bool ping_sent_successfully;
-    bool pong_received_or_ping_handled; bool test_finished_signal;
-} xsan_comm_test_state_t;
-static xsan_comm_test_state_t g_comm_test_controller;
+    bool completed;
+    xsan_error_t status;
+    char *buffer;
+    const char *original_buffer_for_verify;
+    uint64_t len;
+    const char* test_name;
+    struct spdk_thread *thread;
+} xsan_e2e_io_test_ctx_t;
+static void _e2e_io_completion_cb(void *cb_arg, xsan_error_t status);
 
-typedef struct {
-    struct spdk_sock *originating_sock; xsan_volume_manager_t *vm;
-    xsan_message_header_t original_req_header;
-    union { xsan_replica_write_req_payload_t write_req_payload; xsan_replica_read_req_payload_t read_req_payload; } req_payload_data;
-    void *dma_buffer; uint64_t data_len_bytes; bool is_read_op_on_replica;
-} xsan_replica_op_handler_ctx_t;
 
-static void _finalize_async_io_test_sequence(xsan_async_io_test_control_t *test_ctrl);
-static void _async_io_test_phase_complete_cb(void *cb_arg, xsan_error_t status);
-
+// --- Original Test Callbacks & Stubs (might be refactored/removed later if E2E test replaces them) ---
 static void _log_volume_and_replica_states(xsan_volume_manager_t *vm, xsan_volume_id_t vol_id, const char *log_prefix) {
     if (!vm || spdk_uuid_is_null((struct spdk_uuid*)&vol_id.data[0])) return;
     xsan_volume_t *vol = xsan_volume_get_by_id(vm, vol_id);
@@ -86,12 +79,8 @@ static void _log_volume_and_replica_states(xsan_volume_manager_t *vm, xsan_volum
                           vol->replica_nodes[i].node_comm_port, vol->replica_nodes[i].state,
                           vol->replica_nodes[i].last_successful_contact_time_us);
         }
-    } else {
-        XSAN_LOG_WARN("%s Volume ID %s not found for state logging.", log_prefix, spdk_uuid_get_string((struct spdk_uuid*)&vol_id.data[0]));
-    }
+    } else { XSAN_LOG_WARN("%s Volume ID %s not found for state logging.", log_prefix, spdk_uuid_get_string((struct spdk_uuid*)&vol_id.data[0]));}
 }
-
-
 static void _finalize_async_io_test_sequence(xsan_async_io_test_control_t *test_ctrl) {
     if (test_ctrl && test_ctrl->outstanding_io_ops == 0 && !test_ctrl->test_finished_signal) {
         XSAN_LOG_INFO("[AsyncIOTest] Sequence finished, final phase: %d.", test_ctrl->current_phase);
@@ -99,31 +88,22 @@ static void _finalize_async_io_test_sequence(xsan_async_io_test_control_t *test_
         if(test_ctrl->read_buffer_dma1) xsan_bdev_dma_free(test_ctrl->read_buffer_dma1); test_ctrl->read_buffer_dma1=NULL;
         if(test_ctrl->write_buffer_dma2) xsan_bdev_dma_free(test_ctrl->write_buffer_dma2); test_ctrl->write_buffer_dma2=NULL;
         if(test_ctrl->read_buffer_dma2) xsan_bdev_dma_free(test_ctrl->read_buffer_dma2); test_ctrl->read_buffer_dma2=NULL;
-
-        // Log final states after test involving potential failure
         if (!spdk_uuid_is_null((struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0])) {
             _log_volume_and_replica_states(test_ctrl->vm, test_ctrl->volume_id_to_test, "[AsyncIOTestFinalState]");
         }
         test_ctrl->test_finished_signal = true;
     }
 }
-
 static void _async_io_test_phase_complete_cb(void *cb_arg, xsan_error_t status) {
-    xsan_async_io_test_control_t *ctx = (xsan_async_io_test_control_t *)cb_arg;
-    ctx->outstanding_io_ops--;
-    xsan_error_t submit_err = XSAN_OK;
-    char vol_id_s[SPDK_UUID_STRING_LEN]; spdk_uuid_fmt_lower(vol_id_s, sizeof(vol_id_s), (struct spdk_uuid*)&ctx->volume_id_to_test.data[0]);
-
-    if (status != XSAN_OK &&
-        (ctx->current_phase != ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED) && /* For WRITE2, error is expected for the overall rep_write */
-        (ctx->current_phase != ASYNC_IO_TEST_PHASE_READ2_AFTER_FAILED_REPLICA_SUBMITTED && status == XSAN_ERROR_NOT_FOUND) /* Allow NOT_FOUND for read after simulated replica failure if all replicas are "failed" */
-        ) {
-        XSAN_LOG_ERROR("[AsyncIOTest] Phase %d for vol %s FAILED (XSAN Status: %d %s)", ctx->current_phase, vol_id_s, status, xsan_error_string(status));
-        ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED;
-        goto end_phase_logic_async_io_test;
+    xsan_async_io_test_control_t *ctx = (xsan_async_io_test_control_t *)cb_arg; ctx->outstanding_io_ops--;
+    xsan_error_t submit_err = XSAN_OK; char vol_id_s[SPDK_UUID_STRING_LEN];
+    spdk_uuid_fmt_lower(vol_id_s, sizeof(vol_id_s), (struct spdk_uuid*)&ctx->volume_id_to_test.data[0]);
+    if (status != XSAN_OK && (ctx->current_phase != ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED) &&
+        (ctx->current_phase != ASYNC_IO_TEST_PHASE_READ2_AFTER_FAILED_REPLICA_SUBMITTED && status == XSAN_ERROR_NOT_FOUND) ) {
+        XSAN_LOG_ERROR("[AsyncIOTest] Phase %d for vol %s FAILED (Status: %d %s)", ctx->current_phase, vol_id_s, status, xsan_error_string(status));
+        ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED; goto end_phase_logic_async_io_test;
     }
     XSAN_LOG_INFO("[AsyncIOTest] Phase %d for vol %s completed with status %d.", ctx->current_phase, vol_id_s, status);
-
     switch(ctx->current_phase) {
         case ASYNC_IO_TEST_PHASE_WRITE1_SUBMITTED:
             ctx->current_phase = ASYNC_IO_TEST_PHASE_READ1_SUBMITTED; ctx->outstanding_io_ops++;
@@ -137,21 +117,15 @@ static void _async_io_test_phase_complete_cb(void *cb_arg, xsan_error_t status) 
                 g_simulate_replica_local_write_failure = true;
                 ctx->current_phase = ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED; ctx->outstanding_io_ops++;
                 snprintf((char*)ctx->write_buffer_dma2, ctx->io_block_size, "XSAN Async Test RUN 2 (expect replica fail) Vol %s", vol_id_s);
-                 for(size_t k=strlen((char*)ctx->write_buffer_dma2); k < ctx->io_block_size; ++k) { ((char*)ctx->write_buffer_dma2)[k] = (char)((k % 240) + 10); } // Different pattern
+                for(size_t k=strlen((char*)ctx->write_buffer_dma2); k < ctx->io_block_size; ++k) { ((char*)ctx->write_buffer_dma2)[k] = (char)((k % 240) + 10); }
                 submit_err = xsan_volume_write_async(ctx->vm, ctx->volume_id_to_test, 0, ctx->io_block_size, ctx->write_buffer_dma2, _async_io_test_phase_complete_cb, ctx);
-            } else {
-                XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W1 data verify for vol %s FAILED!", vol_id_s);
-                ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED;
-            }
+            } else { XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W1 data verify for vol %s FAILED!", vol_id_s); ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED; }
             break;
         case ASYNC_IO_TEST_PHASE_WRITE2_FAILED_REPLICA_SUBMITTED:
-            if (status == XSAN_OK) {
-                 XSAN_LOG_WARN("[AsyncIOTest] Write2 (FTT=1, one replica simulated fail) reported OVERALL SUCCESS. This means primary write succeeded and replication policy (e.g. W=1) allowed it.");
-            } else {
-                 XSAN_LOG_INFO("[AsyncIOTest] Write2 (FTT=1, one replica simulated fail) reported OVERALL FAILURE as expected for strict W=N+1: %s", xsan_error_string(status));
-            }
+            if (status == XSAN_OK) { XSAN_LOG_WARN("[AsyncIOTest] Write2 (FTT=1, one replica simulated fail) reported OVERALL SUCCESS.");}
+            else { XSAN_LOG_INFO("[AsyncIOTest] Write2 (FTT=1, one replica simulated fail) reported OVERALL FAILURE as expected: %s", xsan_error_string(status));}
             g_simulate_replica_local_write_failure = false;
-            _log_volume_and_replica_states(ctx->vm, ctx->volume_id_to_test, "[AsyncIOTestAfterW2Fail]"); // Log states
+            _log_volume_and_replica_states(ctx->vm, ctx->volume_id_to_test, "[AsyncIOTestAfterW2Fail]");
             ctx->current_phase = ASYNC_IO_TEST_PHASE_READ2_AFTER_FAILED_REPLICA_SUBMITTED; ctx->outstanding_io_ops++;
             submit_err = xsan_volume_read_async(ctx->vm, ctx->volume_id_to_test, 0, ctx->io_block_size, ctx->read_buffer_dma2, _async_io_test_phase_complete_cb, ctx);
             break;
@@ -159,10 +133,7 @@ static void _async_io_test_phase_complete_cb(void *cb_arg, xsan_error_t status) 
             if (status == XSAN_OK && memcmp(ctx->write_buffer_dma2, ctx->read_buffer_dma2, ctx->io_block_size) == 0) {
                 XSAN_LOG_INFO("SUCCESS: [AsyncIOTest] R/W2 data (after simulated replica fail) verify for vol %s PASSED on primary!", vol_id_s);
                 ctx->current_phase = ASYNC_IO_TEST_PHASE_VERIFY2_DONE;
-            } else {
-                XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W2 data (after simulated replica fail) verify for vol %s FAILED on primary! Read status: %d", vol_id_s, status);
-                ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED;
-            }
+            } else { XSAN_LOG_ERROR("FAILURE: [AsyncIOTest] R/W2 data (after simulated replica fail) verify for vol %s FAILED on primary! Read status: %d", vol_id_s, status); ctx->current_phase = ASYNC_IO_TEST_PHASE_FAILED; }
             break;
         default: break;
     }
@@ -170,386 +141,278 @@ static void _async_io_test_phase_complete_cb(void *cb_arg, xsan_error_t status) 
         XSAN_LOG_ERROR("[AsyncIOTest] Failed to submit next phase %d for vol %s: %s", ctx->current_phase, vol_id_s, xsan_error_string(submit_err));
         ctx->outstanding_io_ops--; ctx->current_phase=ASYNC_IO_TEST_PHASE_FAILED;
     }
-end_phase_logic_async_io_test:
-    _finalize_async_io_test_sequence(ctx);
+end_phase_logic_async_io_test: _finalize_async_io_test_sequence(ctx);
 }
-static void _start_async_io_test_on_volume(xsan_async_io_test_control_t *test_ctrl, xsan_volume_t *vol_to_test) { /* ... as before, starts WRITE1 ... */
+static void _start_async_io_test_on_volume(xsan_async_io_test_control_t *test_ctrl, xsan_volume_t *vol_to_test) {
     if(!vol_to_test || vol_to_test->block_size_bytes==0){_finalize_async_io_test_sequence(test_ctrl);return;}
     memcpy(&test_ctrl->volume_id_to_test, &vol_to_test->id, sizeof(xsan_volume_id_t)); test_ctrl->io_block_size = vol_to_test->block_size_bytes;
     xsan_disk_group_t *g=xsan_disk_manager_find_disk_group_by_id(test_ctrl->dm,vol_to_test->source_group_id); if (!g || g->disk_count == 0) {_finalize_async_io_test_sequence(test_ctrl); return; }
-    xsan_disk_t *d0=xsan_disk_manager_find_disk_by_id(test_ctrl->dm,g->disk_ids[0]); if (!d0) {_finalize_async_io_test_sequence(test_ctrl); return; }
+    xsan_disk_t *d0=xsan_disk_manager_find_disk_by_id(test_ctrl->dm,g->disk_ids[0]); if (!d0 || !d0->bdev_name[0]) {_finalize_async_io_test_sequence(test_ctrl); return; }
     test_ctrl->dma_alignment=xsan_bdev_get_buf_align(d0->bdev_name);
     test_ctrl->write_buffer_dma1=xsan_bdev_dma_malloc(test_ctrl->io_block_size,test_ctrl->dma_alignment); test_ctrl->read_buffer_dma1=xsan_bdev_dma_malloc(test_ctrl->io_block_size,test_ctrl->dma_alignment);
     test_ctrl->write_buffer_dma2=xsan_bdev_dma_malloc(test_ctrl->io_block_size,test_ctrl->dma_alignment); test_ctrl->read_buffer_dma2=xsan_bdev_dma_malloc(test_ctrl->io_block_size,test_ctrl->dma_alignment);
-    if(!test_ctrl->write_buffer_dma1||!test_ctrl->read_buffer_dma1||!test_ctrl->write_buffer_dma2||!test_ctrl->read_buffer_dma2){/*free,finalize*/_finalize_async_io_test_sequence(test_ctrl);return;}
-
+    if(!test_ctrl->write_buffer_dma1||!test_ctrl->read_buffer_dma1||!test_ctrl->write_buffer_dma2||!test_ctrl->read_buffer_dma2){ _finalize_async_io_test_sequence(test_ctrl);return;}
     char vol_id_str[SPDK_UUID_STRING_LEN]; spdk_uuid_fmt_lower(vol_id_str, sizeof(vol_id_str), (struct spdk_uuid*)&test_ctrl->volume_id_to_test.data[0]);
     snprintf((char*)test_ctrl->write_buffer_dma1, test_ctrl->io_block_size, "XSAN Async Test RUN 1! Vol %s", vol_id_str);
     for(size_t k=strlen((char*)test_ctrl->write_buffer_dma1); k < test_ctrl->io_block_size; ++k) { ((char*)test_ctrl->write_buffer_dma1)[k] = (char)((k % 250) + 5); }
-    memset(test_ctrl->read_buffer_dma1, 0xDD, test_ctrl->io_block_size);
-    memset(test_ctrl->read_buffer_dma2, 0xEE, test_ctrl->io_block_size);
-
+    memset(test_ctrl->read_buffer_dma1, 0xDD, test_ctrl->io_block_size); memset(test_ctrl->read_buffer_dma2, 0xEE, test_ctrl->io_block_size);
     XSAN_LOG_INFO("--- Starting Async R/W Test Sequence on Volume ID %s (FTT: %u) ---", vol_id_str, vol_to_test->FTT);
     _log_volume_and_replica_states(test_ctrl->vm, test_ctrl->volume_id_to_test, "[AsyncIOTestPreW1]");
-
     test_ctrl->current_phase=ASYNC_IO_TEST_PHASE_WRITE1_SUBMITTED; test_ctrl->outstanding_io_ops++;
     xsan_error_t err = xsan_volume_write_async(test_ctrl->vm,test_ctrl->volume_id_to_test,0,test_ctrl->io_block_size,test_ctrl->write_buffer_dma1,_async_io_test_phase_complete_cb,test_ctrl);
     if(err!=XSAN_OK){ test_ctrl->outstanding_io_ops--;test_ctrl->current_phase=ASYNC_IO_TEST_PHASE_FAILED;_finalize_async_io_test_sequence(test_ctrl); }
 }
 
-// --- Node Comm Test Callbacks & State --- (Simplified, as before)
-static void _comm_test_send_ping_cb(int st, void *arg){xsan_comm_test_state_t*s=arg;if(st==0)s->ping_sent_successfully=true;else s->test_finished_signal=true;}
-static void _comm_test_connect_cb(struct spdk_sock *sk, int st, void *arg){ /* ... */ }
-
-// --- Replica I/O Request Handling (Simulated on self) ---
-static void _replica_op_response_send_complete_cb(int status, void *cb_arg) { /* ... as before ... */ }
-static void _replica_op_local_io_done_cb(void *cb_arg, xsan_error_t local_io_status) {
-    xsan_replica_op_handler_ctx_t *h_ctx = cb_arg; if(!h_ctx) return;
-    xsan_error_t final_status_for_replica = local_io_status;
-
-    if (g_simulate_replica_local_write_failure && !h_ctx->is_read_op_on_replica) {
-        XSAN_LOG_WARN("[ReplicaHandler] SIMULATING local write failure for TID %lu as requested by test.", h_ctx->original_req_header.transaction_id);
-        final_status_for_replica = XSAN_ERROR_IO;
-        g_simulate_replica_local_write_failure = false; // Reset flag for next op if any
-    }
-    // ... (rest of the function to build and send response, as before) ...
-    xsan_message_type_t resp_msg_type; size_t resp_struct_payload_size;
-    unsigned char resp_struct_payload_buf[sizeof(xsan_replica_write_resp_payload_t)];
-    void *data_for_resp_msg = NULL; uint32_t data_len_for_resp_msg = 0;
-    if(h_ctx->is_read_op_on_replica){/* ... read resp ... */} else {/* ... write resp ... */}
-    // ... (create and send message logic) ...
-    // For brevity, assuming the rest of this function (from previous overwrite) is correct
-    // and it calls _replica_op_response_send_complete_cb which frees h_ctx and its dma_buffer.
+static void _xsan_node_test_message_handler(struct xsan_connection_ctx *conn_ctx, xsan_message_t *msg, void *cb_arg_vol_mgr) {
+    XSAN_LOG_INFO("Test Handler: Received msg type %u from %s", msg->header.type, conn_ctx->peer_addr_str);
+    xsan_protocol_message_destroy(msg);
 }
-
-static void _xsan_node_test_message_handler(struct spdk_sock *sock, const char *peer, xsan_message_t *msg, void *cb_arg) { /* ... as before ... */ }
-
-static char *g_xsan_config_file = NULL; // To be set by command line arg
-
-static void xsan_node_main_spdk_thread_start(void *arg1, int spdk_startup_rc) {
-    XSAN_LOG_INFO("XSAN Node main SPDK thread started. SPDK Startup RC: %d", spdk_startup_rc);
-    if (spdk_startup_rc != 0) {
-        XSAN_LOG_FATAL("SPDK framework failed to start properly (rc=%d). Exiting XSAN node main.", spdk_startup_rc);
-        // Signal app stop if necessary, or handle based on how spdk_app_start behaves on error for its main fn.
-        // If spdk_app_start calls this even on its own error, we should probably just return.
-        return;
-    }
-
-    // Initialize global config
-    g_xsan_config = xsan_config_create();
-    if (!g_xsan_config) {
-        XSAN_LOG_FATAL("Failed to create global config object. Shutting down.");
-        xsan_spdk_manager_request_app_stop();
-        return;
-    }
-
-    const char *config_file_to_load = g_xsan_config_file ? g_xsan_config_file : "xsan_node.conf";
-    XSAN_LOG_INFO("Loading XSAN configuration from: %s", config_file_to_load);
-
-    if (!xsan_config_load_from_file(g_xsan_config, config_file_to_load)) {
-        XSAN_LOG_ERROR("Failed to load config file '%s'. Some features might use defaults or fail.", config_file_to_load);
-        // Depending on strictness, could decide to stop here. For now, proceed with potential defaults.
-    }
-
-    // Load node-specific configuration
-    if (!xsan_config_load_node_config(g_xsan_config, &g_local_node_config)) {
-        XSAN_LOG_ERROR("Failed to parse node-specific config. Critical error. Shutting down.");
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-        xsan_spdk_manager_request_app_stop();
-        return;
-    } else {
-        XSAN_LOG_INFO("Node Config Loaded: ID='%s', Name='%s', Addr='%s', Port=%u, DataDir='%s'",
-                      g_local_node_config.node_id, g_local_node_config.node_name,
-                      g_local_node_config.bind_address, g_local_node_config.port, g_local_node_config.data_dir);
-        if (strlen(g_local_node_config.node_id) == 0 || strcmp(g_local_node_config.node_id, "undefined") == 0) { // Example validation
-             XSAN_LOG_FATAL("Node ID is invalid ('%s') in config. Cannot proceed. Shutting down.", g_local_node_config.node_id);
-             xsan_config_destroy(g_xsan_config);
-             g_xsan_config = NULL;
-             xsan_spdk_manager_request_app_stop();
-             return;
-        }
-        // TODO: Convert g_local_node_config.node_id (string) to g_local_xsan_node_id (xsan_node_id_t/UUID)
-        // if (spdk_uuid_parse(&g_local_xsan_node_id.data[0], g_local_node_config.node_id) != 0) {
-        //    XSAN_LOG_FATAL("Failed to parse configured node_id '%s' as UUID. Shutting down.", g_local_node_config.node_id);
-        //    // ... cleanup and stop ...
-        // }
-    }
-
-    // Load cluster-specific configuration (optional for now, but good for completeness)
-    if (!xsan_config_load_cluster_config(g_xsan_config, &g_cluster_config)) {
-        XSAN_LOG_WARN("Failed to parse cluster-specific config. Cluster operations might be limited.");
-    } else {
-        XSAN_LOG_INFO("Cluster Config Loaded: Name='%s', SeedNodesCount=%zu",
-                      g_cluster_config.cluster_name, g_cluster_config.seed_node_count);
-    }
-
-    // Initialize other XSAN managers that depend on config or SPDK
-
-    // Initialize Cluster module (depends on global config g_cluster_config being populated)
-    if (xsan_cluster_init(config_file_to_load) != XSAN_OK) { // Pass config path for context, though current init uses globals
-        XSAN_LOG_FATAL("Failed to initialize XSAN Cluster Manager. Shutting down.");
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-        xsan_spdk_manager_request_app_stop();
-        return;
-    }
-
-    xsan_disk_manager_t *disk_manager = NULL;
-    if (xsan_disk_manager_init(&disk_manager) != XSAN_OK) {
-        XSAN_LOG_FATAL("Failed to initialize XSAN Disk Manager. Shutting down.");
-        xsan_cluster_shutdown();
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-        xsan_spdk_manager_request_app_stop();
-        return;
-    }
-    xsan_disk_manager_scan_and_register_bdevs(disk_manager);
-
-
-    xsan_volume_manager_t *volume_manager = NULL;
-    if (xsan_volume_manager_init(disk_manager, &volume_manager) != XSAN_OK) {
-        XSAN_LOG_FATAL("Failed to initialize XSAN Volume Manager. Shutting down.");
-        xsan_disk_manager_fini(&disk_manager);
-        xsan_cluster_shutdown();
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-        xsan_spdk_manager_request_app_stop();
-        return;
-    }
-
-    // Initialize node communication server (listener)
-    // The global_app_msg_handler_cb in xsan_node_comm_init can be NULL if all messages are handled by specific handlers.
-    if (xsan_node_comm_init(g_local_node_config.bind_address, g_local_node_config.port, NULL, NULL) != XSAN_OK) {
-         XSAN_LOG_FATAL("Failed to initialize XSAN node communication server on %s:%u. Shutting down.",
-                       g_local_node_config.bind_address, g_local_node_config.port);
-        xsan_volume_manager_fini(&volume_manager);
-        xsan_disk_manager_fini(&disk_manager);
-        xsan_cluster_shutdown();
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-        xsan_spdk_manager_request_app_stop();
-        return;
-    }
-    // Register specific handlers for replica operations
-    if (xsan_node_comm_register_message_handler(XSAN_MSG_TYPE_REPLICA_WRITE_BLOCK_REQ,
-                                                xsan_volume_manager_handle_replica_write_req,
-                                                volume_manager) != XSAN_OK) {
-        XSAN_LOG_FATAL("Failed to register replica write request handler. Shutting down.");
-        // ... cleanup and stop ...
-        return;
-    }
-    if (xsan_node_comm_register_message_handler(XSAN_MSG_TYPE_REPLICA_READ_BLOCK_REQ,
-                                                xsan_volume_manager_handle_replica_read_req,
-                                                volume_manager) != XSAN_OK) {
-        XSAN_LOG_FATAL("Failed to register replica read request handler. Shutting down.");
-        // ... cleanup and stop ...
-        return;
-    }
-    // Note: _xsan_node_test_message_handler was the old global handler.
-    // If it's still needed for other message types, it could be registered for those,
-    // or xsan_node_comm_init's global handler could be set to it if specific handlers are not found.
-    // For now, assuming replica ops are the primary ones handled via specific registration.
-
-
-    XSAN_LOG_INFO("XSAN Node subsystems initialized. Running test sequences or waiting for events...");
-
-    // Run End-to-End Core Logic Tests
-    _run_e2e_core_logic_tests(disk_manager, volume_manager);
-
-
-    XSAN_LOG_INFO("XSAN Node main SPDK thread tasks complete. Cleaning up XSAN subsystems...");
-
-    // Cleanup XSAN subsystems
-    xsan_node_comm_fini(); // Updated to reflect new comm_init/fini
-    xsan_volume_manager_fini(&volume_manager);
-    xsan_disk_manager_fini(&disk_manager);
-    xsan_cluster_shutdown(); // Shutdown cluster module
-
-    if (g_xsan_config) {
-        xsan_config_destroy(g_xsan_config);
-        g_xsan_config = NULL;
-    }
-    XSAN_LOG_INFO("XSAN subsystems cleaned up. Requesting SPDK application stop.");
-    xsan_spdk_manager_request_app_stop(); // Signal SPDK app to stop all reactors
-}
-
 
 // --- E2E Test Helper Structures and Callbacks ---
-typedef struct {
-    bool completed;
-    xsan_error_t status;
-    char *buffer; // For reads
-    const char *original_buffer_for_verify; // For comparison after read
-    uint64_t len;
-    const char* test_name;
-    struct spdk_thread *thread; // Thread to signal if polling
-} xsan_e2e_io_test_ctx_t;
-
 static void _e2e_io_completion_cb(void *cb_arg, xsan_error_t status) {
     xsan_e2e_io_test_ctx_t *ctx = (xsan_e2e_io_test_ctx_t *)cb_arg;
     ctx->completed = true;
     ctx->status = status;
-
     XSAN_LOG_INFO("E2E Test '%s' I/O completed with status: %s (%d)", ctx->test_name, xsan_error_string(status), status);
-
     if (status == XSAN_OK && ctx->original_buffer_for_verify && ctx->buffer && ctx->len > 0) {
         if (memcmp(ctx->original_buffer_for_verify, ctx->buffer, ctx->len) == 0) {
             XSAN_LOG_INFO("E2E Test '%s': Read data verification PASSED.", ctx->test_name);
         } else {
             XSAN_LOG_ERROR("E2E Test '%s': Read data verification FAILED!", ctx->test_name);
-            // Hex dump for debugging small differences
-            // xsan_hex_dump("Original", ctx->original_buffer_for_verify, XSAN_MIN(ctx->len, 64));
-            // xsan_hex_dump("Read Back", ctx->buffer, XSAN_MIN(ctx->len, 64));
             ctx->status = XSAN_ERROR_TEST_VERIFY_FAILED;
         }
-    }
-    if (ctx->thread) { // If polling, signal the polling loop.
-        // spdk_thread_send_msg(ctx->thread, some_msg_to_break_poll, NULL); // Needs a message mechanism
     }
 }
 
 static void _run_e2e_core_logic_tests(xsan_disk_manager_t *dm, xsan_volume_manager_t *vm) {
     XSAN_LOG_INFO("===== Starting E2E Core Logic Tests =====");
     xsan_error_t err;
-
-    // Test Parameters
-    const char *test_dg_name = "TestDiskGroup1";
-    const char *bdev_names[] = {"Malloc0", "Malloc1"}; // Ensure these are configured in SPDK JSON conf
-    int num_bdevs_for_dg = 2;
-    xsan_group_id_t dg_id;
-
-    const char *test_vol_name = "TestVolume1";
-    uint64_t test_vol_size_mb = 20; // 20 MB
+    const char *test_dg_name = "TestE2EDG1";
+    const char *bdev_names[] = {"Malloc0", "Malloc1"};
+    int num_bdevs_for_dg = (sizeof(bdev_names)/sizeof(bdev_names[0]));
+    xsan_group_id_t dg_id = {0}; // Initialize to suppress maybe-uninitialized
+    const char *test_vol_name = "TestE2EVol1";
+    uint64_t test_vol_size_mb = 20;
     uint64_t test_vol_size_bytes = test_vol_size_mb * 1024 * 1024;
     uint32_t test_vol_block_size = 4096;
-    uint32_t test_vol_ftt = 0; // Single replica for basic I/O test
-    xsan_volume_id_t vol_id;
+    uint32_t test_vol_ftt = 0;
+    xsan_volume_id_t vol_id = {0}; // Initialize
     xsan_volume_t *vol = NULL;
+    uint32_t test_nsid = 1;
+    bool ns_added = false;
 
-    // --- Test Disk Group Creation ---
     XSAN_LOG_INFO("[E2E Test] Creating disk group '%s'...", test_dg_name);
     err = xsan_disk_manager_disk_group_create(dm, test_dg_name, XSAN_DISK_GROUP_TYPE_JBOD, bdev_names, num_bdevs_for_dg, &dg_id);
-    if (err != XSAN_OK) {
-        XSAN_LOG_ERROR("[E2E Test] Failed to create disk group '%s': %s", test_dg_name, xsan_error_string(err));
-        goto test_end;
-    }
-    XSAN_LOG_INFO("[E2E Test] Disk group '%s' (ID: %s) created successfully.", test_dg_name, spdk_uuid_get_string((struct spdk_uuid*)&dg_id.data[0]));
+    if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to create disk group '%s': %s", test_dg_name, xsan_error_string(err)); goto test_end_e2e; }
+    XSAN_LOG_INFO("[E2E Test] Disk group '%s' (ID: %s) created.", test_dg_name, spdk_uuid_get_string((struct spdk_uuid*)&dg_id.data[0]));
 
-    // --- Test Volume Creation ---
     XSAN_LOG_INFO("[E2E Test] Creating volume '%s' (Size: %lu MB, FTT: %u)...", test_vol_name, test_vol_size_mb, test_vol_ftt);
-    err = xsan_volume_create(vm, test_vol_name, test_vol_size_bytes, dg_id, test_vol_block_size, false /*thick*/, test_vol_ftt, &vol_id);
-    if (err != XSAN_OK) {
-        XSAN_LOG_ERROR("[E2E Test] Failed to create volume '%s': %s", test_vol_name, xsan_error_string(err));
-        goto cleanup_dg;
-    }
-    vol = xsan_volume_get_by_id(vm, vol_id); // Get the managed instance
-    if (!vol) {
-        XSAN_LOG_ERROR("[E2E Test] Volume '%s' created but get_by_id failed!", test_vol_name);
-        goto cleanup_dg; // vol_id might be valid for delete if create partially succeeded in metadata
-    }
-    XSAN_LOG_INFO("[E2E Test] Volume '%s' (ID: %s) created successfully. State: %d", test_vol_name, spdk_uuid_get_string((struct spdk_uuid*)&vol_id.data[0]), vol->state);
+    err = xsan_volume_create(vm, test_vol_name, test_vol_size_bytes, dg_id, test_vol_block_size, false, test_vol_ftt, &vol_id);
+    if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to create volume '%s': %s", test_vol_name, xsan_error_string(err)); goto cleanup_dg_e2e; }
+    vol = xsan_volume_get_by_id(vm, vol_id);
+    if (!vol) { XSAN_LOG_ERROR("[E2E Test] Volume '%s' created but get_by_id failed!", test_vol_name); goto cleanup_dg_e2e;}
 
+    XSAN_LOG_INFO("[E2E Test] Volume '%s' (ID: %s) available for NVMe-oF export. State: %d",
+                  test_vol_name, spdk_uuid_get_string((struct spdk_uuid*)&vol_id.data[0]), vol->state);
+    xsan_volume_allocation_meta_t *e2e_alloc_meta = NULL;
+    char e2e_alloc_meta_key[XSAN_MAX_NAME_LEN + SPDK_UUID_STRING_LEN];
+    snprintf(e2e_alloc_meta_key, sizeof(e2e_alloc_meta_key), "%s%s", XSAN_VOL_ALLOC_META_PREFIX, spdk_uuid_get_string((struct spdk_uuid*)&vol_id.data[0]));
+    char *e2e_alloc_meta_json = NULL; size_t e2e_alloc_meta_json_len = 0;
+    if (g_xsan_volume_manager_instance && g_xsan_volume_manager_instance->md_store && // Check vm and md_store
+        xsan_metadata_store_get(g_xsan_volume_manager_instance->md_store, e2e_alloc_meta_key, strlen(e2e_alloc_meta_key), &e2e_alloc_meta_json, &e2e_alloc_meta_json_len) == XSAN_OK && e2e_alloc_meta_json) {
+        if (_xsan_json_string_to_volume_allocation_meta(e2e_alloc_meta_json, &e2e_alloc_meta) == XSAN_OK && e2e_alloc_meta && e2e_alloc_meta->num_extents > 0) {
+            xsan_disk_t *first_disk_for_vol = xsan_disk_manager_find_disk_by_id(dm, e2e_alloc_meta->extents[0].disk_id);
+            if (first_disk_for_vol && first_disk_for_vol->bdev_name[0] != '\0') {
+                char vol_uuid_str_for_ns[SPDK_UUID_STRING_LEN];
+                spdk_uuid_fmt_lower(vol_uuid_str_for_ns, sizeof(vol_uuid_str_for_ns), (struct spdk_uuid*)&vol_id.data[0]);
+                XSAN_LOG_INFO("[E2E Test] Adding bdev '%s' as NVMe-oF namespace (NSID %u) for volume '%s'", first_disk_for_vol->bdev_name, test_nsid, test_vol_name);
+                err = xsan_nvmf_target_add_namespace(first_disk_for_vol->bdev_name, test_nsid, vol_uuid_str_for_ns);
+                if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to add namespace for bdev '%s': %s", first_disk_for_vol->bdev_name, xsan_error_string(err));}
+                else {
+                    XSAN_LOG_INFO("[E2E Test] Namespace NSID %u added for bdev %s.", test_nsid, first_disk_for_vol->bdev_name);
+                    XSAN_LOG_INFO("To test from initiator (same machine):");
+                    XSAN_LOG_INFO("1. sudo nvme discover -t tcp -a %s -s %s", g_local_node_config.bind_address, g_local_node_config.nvmf_listen_port);
+                    XSAN_LOG_INFO("2. sudo nvme connect -t tcp -n %s -a %s -s %s",
+                                  g_local_node_config.nvmf_target_nqn[0] ? g_local_node_config.nvmf_target_nqn : "nqn.2024-01.org.xsan:tgt1",
+                                  g_local_node_config.bind_address, g_local_node_config.nvmf_listen_port);
+                    XSAN_LOG_INFO("3. sudo nvme list");
+                    XSAN_LOG_INFO("Pausing for 60 seconds for manual NVMe-oF client tests...");
+                    sleep(60);
+                    ns_added = true;
+                }
+            } else { XSAN_LOG_WARN("[E2E Test] Could not find bdev name for first extent of volume '%s' to expose.", test_vol_name); }
+        } else { XSAN_LOG_WARN("[E2E Test] Failed to deserialize alloc meta for vol %s.", test_vol_name); }
+        if (e2e_alloc_meta) XSAN_FREE(e2e_alloc_meta);
+        if (e2e_alloc_meta_json) XSAN_FREE(e2e_alloc_meta_json);
+    } else { XSAN_LOG_WARN("[E2E Test] Could not load allocation metadata for volume '%s' to expose as namespace.", test_vol_name); }
 
-    // --- Test LBA Mapping (simple check) ---
-    xsan_disk_id_t mapped_disk_id;
-    uint64_t mapped_phys_lba;
-    uint32_t mapped_phys_block_size;
-    uint64_t test_lba = 0; // Test mapping for LBA 0
+    xsan_disk_id_t mapped_disk_id; uint64_t mapped_phys_lba; uint32_t mapped_phys_block_size;
+    uint64_t test_lba = 0;
     XSAN_LOG_INFO("[E2E Test] Mapping LBA %lu for volume '%s'...", test_lba, test_vol_name);
     err = xsan_volume_map_lba_to_physical(vm, vol_id, test_lba, &mapped_disk_id, &mapped_phys_lba, &mapped_phys_block_size);
-    if (err != XSAN_OK) {
-        XSAN_LOG_ERROR("[E2E Test] Failed to map LBA %lu for volume '%s': %s", test_lba, test_vol_name, xsan_error_string(err));
-    } else {
-        XSAN_LOG_INFO("[E2E Test] LBA %lu maps to DiskID: %s, PhysLBA: %lu, PhysBlkSize: %u",
-                      test_lba, spdk_uuid_get_string((struct spdk_uuid*)&mapped_disk_id.data[0]), mapped_phys_lba, mapped_phys_block_size);
-        // TODO: Add more specific verification based on known Malloc0/Malloc1 properties if needed
-    }
+    if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to map LBA %lu: %s", test_lba, xsan_error_string(err));}
+    else { XSAN_LOG_INFO("[E2E Test] LBA %lu maps to DiskID: %s, PhysLBA: %lu, PhysBlkSize: %u", test_lba, spdk_uuid_get_string((struct spdk_uuid*)&mapped_disk_id.data[0]), mapped_phys_lba, mapped_phys_block_size);}
 
-    // --- Test Basic I/O ---
-    uint32_t io_size = test_vol_block_size * 2; // Write 2 blocks
-    char *write_buf = xsan_bdev_dma_malloc(io_size, test_vol_block_size); // Assuming test_vol_block_size is suitable alignment
+    uint32_t io_size = test_vol_block_size * 2;
+    char *write_buf = xsan_bdev_dma_malloc(io_size, test_vol_block_size);
     char *read_buf = xsan_bdev_dma_malloc(io_size, test_vol_block_size);
-    if (!write_buf || !read_buf) {
-        XSAN_LOG_ERROR("[E2E Test] Failed to allocate DMA buffers for I/O test.");
-        if(write_buf) xsan_bdev_dma_free(write_buf);
-        if(read_buf) xsan_bdev_dma_free(read_buf);
-        goto cleanup_vol;
-    }
-    for (uint32_t i = 0; i < io_size; ++i) write_buf[i] = (char)(i % 256);
-    memset(read_buf, 0xAA, io_size);
+    if (!write_buf || !read_buf) { XSAN_LOG_ERROR("[E2E Test] Failed to alloc DMA buffers."); if(write_buf) xsan_bdev_dma_free(write_buf); if(read_buf) xsan_bdev_dma_free(read_buf); goto cleanup_vol_e2e;}
+    for (uint32_t i = 0; i < io_size; ++i) write_buf[i] = (char)((i + 5) % 256);
+    memset(read_buf, 0xBB, io_size);
 
-    xsan_e2e_io_test_ctx_t write_io_ctx = {
-        .completed = false, .status = XSAN_OK, .buffer = NULL, .original_buffer_for_verify = NULL, .len = io_size, .test_name = "WriteTest", .thread = spdk_get_thread()
-    };
-    xsan_e2e_io_test_ctx_t read_io_ctx = {
-        .completed = false, .status = XSAN_OK, .buffer = read_buf, .original_buffer_for_verify = write_buf, .len = io_size, .test_name = "ReadVerifyTest", .thread = spdk_get_thread()
-    };
-    uint64_t io_offset = 0; // Write to start of volume
+    xsan_e2e_io_test_ctx_t write_io_ctx = { .completed = false, .status = XSAN_OK, .len = io_size, .test_name = "E2E_WriteTest", .thread = spdk_get_thread()};
+    xsan_e2e_io_test_ctx_t read_io_ctx = { .completed = false, .status = XSAN_OK, .buffer = read_buf, .original_buffer_for_verify = write_buf, .len = io_size, .test_name = "E2E_ReadVerifyTest", .thread = spdk_get_thread()};
+    uint64_t io_offset = test_vol_block_size * 5;
+    if (io_offset + io_size > test_vol_size_bytes) { XSAN_LOG_WARN("[E2E Test] IO offset+size exceeds vol size. Reducing IO size."); io_size = test_vol_block_size; write_io_ctx.len = read_io_ctx.len = io_size;}
 
-    XSAN_LOG_INFO("[E2E Test] Submitting async write (offset %lu, len %u) to volume '%s'...", io_offset, io_size, test_vol_name);
+    XSAN_LOG_INFO("[E2E Test] Submitting async write (offset %lu, len %u) to vol '%s'...", io_offset, io_size, test_vol_name);
     err = xsan_volume_write_async(vm, vol_id, io_offset, io_size, write_buf, _e2e_io_completion_cb, &write_io_ctx);
-    if (err != XSAN_OK) {
-        XSAN_LOG_ERROR("[E2E Test] Failed to submit write: %s", xsan_error_string(err));
-    } else {
-        while (!write_io_ctx.completed) { spdk_thread_poll(write_io_ctx.thread, 0, 0); usleep(100); } // Simple poll
+    if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to submit write: %s", xsan_error_string(err));}
+    else {
+        while (!write_io_ctx.completed) { spdk_thread_poll(write_io_ctx.thread, 0, 0); usleep(500); }
         if (write_io_ctx.status == XSAN_OK) {
             XSAN_LOG_INFO("[E2E Test] Write successful. Submitting async read...");
             err = xsan_volume_read_async(vm, vol_id, io_offset, io_size, read_buf, _e2e_io_completion_cb, &read_io_ctx);
-            if (err != XSAN_OK) {
-                XSAN_LOG_ERROR("[E2E Test] Failed to submit read: %s", xsan_error_string(err));
-            } else {
-                while (!read_io_ctx.completed) { spdk_thread_poll(read_io_ctx.thread, 0, 0); usleep(100); }
-                if (read_io_ctx.status != XSAN_OK && read_io_ctx.status != XSAN_ERROR_TEST_VERIFY_FAILED) { // Check if read op itself failed
-                     XSAN_LOG_ERROR("[E2E Test] Read operation failed with: %s", xsan_error_string(read_io_ctx.status));
-                }
+            if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to submit read: %s", xsan_error_string(err));}
+            else {
+                while (!read_io_ctx.completed) { spdk_thread_poll(read_io_ctx.thread, 0, 0); usleep(500); }
+                if (read_io_ctx.status != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Read/Verify phase status: %s", xsan_error_string(read_io_ctx.status));}
             }
-        } else {
-             XSAN_LOG_ERROR("[E2E Test] Write operation failed with: %s", xsan_error_string(write_io_ctx.status));
-        }
+        } else { XSAN_LOG_ERROR("[E2E Test] Write operation failed: %s", xsan_error_string(write_io_ctx.status));}
     }
-    xsan_bdev_dma_free(write_buf);
-    xsan_bdev_dma_free(read_buf);
+    xsan_bdev_dma_free(write_buf); xsan_bdev_dma_free(read_buf);
 
-cleanup_vol:
+cleanup_vol_e2e:
+    if (ns_added) {
+        XSAN_LOG_INFO("[E2E Test] Removing NVMe-oF namespace NSID %u before deleting volume...", test_nsid);
+        err = xsan_nvmf_target_remove_namespace(test_nsid);
+        if (err != XSAN_OK) { XSAN_LOG_ERROR("[E2E Test] Failed to remove namespace NSID %u: %s", test_nsid, xsan_error_string(err));}
+        else { XSAN_LOG_INFO("[E2E Test] Namespace NSID %u removed.", test_nsid); }
+    }
     XSAN_LOG_INFO("[E2E Test] Deleting volume '%s'...", test_vol_name);
-    err = xsan_volume_delete(vm, vol_id);
-    if (err != XSAN_OK) XSAN_LOG_ERROR("[E2E Test] Failed to delete volume '%s': %s", test_vol_name, xsan_error_string(err));
-    else XSAN_LOG_INFO("[E2E Test] Volume '%s' deleted.", test_vol_name);
-
-cleanup_dg:
+    if (!spdk_uuid_is_null((struct spdk_uuid*)&vol_id.data[0])) { // Only delete if vol_id is valid
+        err = xsan_volume_delete(vm, vol_id);
+        if (err != XSAN_OK) XSAN_LOG_ERROR("[E2E Test] Failed to delete volume '%s': %s", test_vol_name, xsan_error_string(err));
+        else XSAN_LOG_INFO("[E2E Test] Volume '%s' deleted.", test_vol_name);
+    } else { XSAN_LOG_WARN("[E2E Test] Volume ID was null, skipping delete for volume '%s'", test_vol_name); }
+cleanup_dg_e2e:
     XSAN_LOG_INFO("[E2E Test] Deleting disk group '%s'...", test_dg_name);
-    err = xsan_disk_manager_disk_group_delete(dm, dg_id);
-    if (err != XSAN_OK) XSAN_LOG_ERROR("[E2E Test] Failed to delete disk group '%s': %s", test_dg_name, xsan_error_string(err));
-    else XSAN_LOG_INFO("[E2E Test] Disk group '%s' deleted.", test_dg_name);
-
-test_end:
+    if (!spdk_uuid_is_null((struct spdk_uuid*)&dg_id.data[0])) { // Only delete if dg_id is valid
+        err = xsan_disk_manager_disk_group_delete(dm, dg_id);
+        if (err != XSAN_OK) XSAN_LOG_ERROR("[E2E Test] Failed to delete disk group '%s': %s", test_dg_name, xsan_error_string(err));
+        else XSAN_LOG_INFO("[E2E Test] Disk group '%s' deleted.", test_dg_name);
+    } else { XSAN_LOG_WARN("[E2E Test] Disk group ID was null, skipping delete for group '%s'", test_dg_name); }
+test_end_e2e:
     XSAN_LOG_INFO("===== E2E Core Logic Tests Finished =====");
-    // Signal main loop in xsan_node_main_spdk_thread_start that tests are done
-    g_async_io_test_controller.test_finished_signal = true; // Reuse this global for now to stop the main loop
+    g_async_io_test_controller.test_finished_signal = true;
 }
 
+
+static void xsan_node_main_spdk_thread_start(void *arg1, int spdk_startup_rc) {
+    XSAN_LOG_INFO("XSAN Node main SPDK thread started. SPDK Startup RC: %d", spdk_startup_rc);
+    if (spdk_startup_rc != 0) {
+        XSAN_LOG_FATAL("SPDK framework failed to start properly (rc=%d). Exiting XSAN node main.", spdk_startup_rc);
+        return;
+    }
+    g_xsan_config = xsan_config_create();
+    if (!g_xsan_config) {
+        XSAN_LOG_FATAL("Failed to create global config object. Shutting down.");
+        xsan_spdk_manager_request_app_stop(); return;
+    }
+    const char *config_file_to_load = g_xsan_config_file ? g_xsan_config_file : "xsan_node.conf";
+    XSAN_LOG_INFO("Loading XSAN configuration from: %s", config_file_to_load);
+    if (!xsan_config_load_from_file(g_xsan_config, config_file_to_load)) {
+        XSAN_LOG_ERROR("Failed to load config file '%s'.", config_file_to_load);
+    }
+    if (!xsan_config_load_node_config(g_xsan_config, &g_local_node_config)) {
+        XSAN_LOG_FATAL("Failed to parse node-specific config. Shutting down.");
+        goto app_cleanup_stop;
+    } else {
+        XSAN_LOG_INFO("Node Config Loaded: ID='%s', Addr='%s', Port=%u, NVMF NQN='%s', NVMF Port='%s'",
+                      g_local_node_config.node_id, g_local_node_config.bind_address, g_local_node_config.port,
+                      g_local_node_config.nvmf_target_nqn, g_local_node_config.nvmf_listen_port);
+        if (strlen(g_local_node_config.node_id) == 0) {
+             XSAN_LOG_FATAL("Node ID is empty. Shutting down."); goto app_cleanup_stop;
+        }
+    }
+    if (!xsan_config_load_cluster_config(g_xsan_config, &g_cluster_config)) {
+        XSAN_LOG_WARN("Failed to parse cluster-specific config.");
+    }
+
+    xsan_disk_manager_t *disk_manager = NULL;
+    xsan_volume_manager_t *volume_manager = NULL;
+
+    if (xsan_cluster_init(config_file_to_load) != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to init XSAN Cluster Manager. Shutting down."); goto app_cleanup_stop;
+    }
+    if (xsan_disk_manager_init(&disk_manager) != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to init XSAN Disk Manager. Shutting down."); goto cluster_cleanup_stop;
+    }
+    xsan_disk_manager_scan_and_register_bdevs(disk_manager);
+    if (xsan_volume_manager_init(disk_manager, &volume_manager) != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to init XSAN Volume Manager. Shutting down."); goto dm_cleanup_stop;
+    }
+    if (xsan_node_comm_init(g_local_node_config.bind_address, g_local_node_config.port, NULL, NULL) != XSAN_OK) {
+         XSAN_LOG_FATAL("Failed to init XSAN node comm server on %s:%u. Shutting down.",
+                       g_local_node_config.bind_address, g_local_node_config.port);
+        goto vm_cleanup_stop;
+    }
+    if (xsan_node_comm_register_message_handler(XSAN_MSG_TYPE_REPLICA_WRITE_BLOCK_REQ,
+                                                xsan_volume_manager_handle_replica_write_req, volume_manager) != XSAN_OK ||
+        xsan_node_comm_register_message_handler(XSAN_MSG_TYPE_REPLICA_READ_BLOCK_REQ,
+                                                xsan_volume_manager_handle_replica_read_req, volume_manager) != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to register replica op handlers. Shutting down.");
+        goto comm_cleanup_stop;
+    }
+    if (xsan_nvmf_target_init(g_local_node_config.nvmf_target_nqn,
+                               g_local_node_config.bind_address,
+                               g_local_node_config.nvmf_listen_port) != XSAN_OK) {
+        XSAN_LOG_FATAL("Failed to initialize XSAN NVMe-oF Target. Shutting down.");
+        goto comm_cleanup_stop;
+    }
+    XSAN_LOG_INFO("XSAN NVMe-oF Target initialized.");
+
+    XSAN_LOG_INFO("XSAN Node subsystems initialized. Running E2E tests or waiting for events...");
+    g_async_io_test_controller.test_finished_signal = false;
+    _run_e2e_core_logic_tests(disk_manager, volume_manager);
+
+    while (!g_async_io_test_controller.test_finished_signal) {
+        spdk_thread_poll(spdk_get_thread(), 0, 0);
+        usleep(10000);
+    }
+
+    XSAN_LOG_INFO("XSAN Node main SPDK thread tasks complete. Cleaning up XSAN subsystems...");
+    xsan_nvmf_target_fini();
+comm_cleanup_stop:
+    xsan_node_comm_fini();
+vm_cleanup_stop:
+    xsan_volume_manager_fini(&volume_manager);
+dm_cleanup_stop:
+    xsan_disk_manager_fini(&disk_manager);
+cluster_cleanup_stop:
+    xsan_cluster_shutdown();
+app_cleanup_stop:
+    if (g_xsan_config) { xsan_config_destroy(g_xsan_config); g_xsan_config = NULL; }
+    XSAN_LOG_INFO("XSAN subsystems cleaned up. Requesting SPDK application stop.");
+    xsan_spdk_manager_request_app_stop();
+}
 
 static void print_usage(const char *program_name) {
     printf("Usage: %s [options]\n", program_name);
     printf("Options:\n");
     printf("  -c, --config FILE      Path to XSAN node configuration file (default: xsan_node.conf)\n");
     printf("  -h, --help             Show this help message\n");
-    // Add other SPDK options if we want to pass them through, e.g., -m for coremask
 }
 
 int main(int argc, char **argv) {
-    // Initialize XSAN logging early
-    // xsan_log_set_level(XSAN_LOG_LEVEL_DEBUG); // Example: set default log level
-    // xsan_log_set_output_file("xsan_node_main.log"); // Example: redirect log
-
-    // Command line argument parsing
     struct option long_options[] = {
         {"config", required_argument, 0, 'c'},
         {"help",   no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
     int opt;
+    g_xsan_config_file = "xsan_node.conf";
+
     while ((opt = getopt_long(argc, argv, "c:h", long_options, NULL)) != -1) {
         switch (opt) {
             case 'c':
@@ -564,30 +427,14 @@ int main(int argc, char **argv) {
         }
     }
 
-
     XSAN_LOG_INFO("XSAN Node application starting...");
-
-    // Initialize SPDK application options
-    // These could also be influenced by command-line arguments if needed.
-    // For now, using some defaults. The JSON config file for SPDK itself is separate.
-    xsan_spdk_manager_opts_init("xsan_node_spdk_app",
-                                 NULL, // SPDK JSON config file (e.g., for bdevs not auto-detected)
-                                 NULL, // Reactor mask (e.g., "0x1", NULL for default)
-                                 true, // Enable RPC
-                                 "/var/tmp/xsan.sock"); // RPC listen address
-
-    // Start the SPDK application framework. This will initialize SPDK environment,
-    // create reactors, and then call xsan_node_main_spdk_thread_start on one of them.
-    // This call is blocking until spdk_app_stop() is called and all reactors exit.
+    xsan_spdk_manager_opts_init("xsan_node_spdk_app", NULL, NULL, true, "/var/tmp/xsan.sock");
     if (xsan_spdk_manager_start_app(xsan_node_main_spdk_thread_start, NULL) != XSAN_OK) {
         XSAN_LOG_FATAL("Failed to start SPDK application framework.");
-        // xsan_config_destroy(g_xsan_config); // g_xsan_config might be null if start_app failed very early
+        if (g_xsan_config) xsan_config_destroy(g_xsan_config); // Ensure config is freed on early exit
         return 1;
     }
-
-    // Finalize SPDK (releases DPDK resources, etc.)
     xsan_spdk_manager_app_fini();
-
     XSAN_LOG_INFO("XSAN Node application finished.");
     return 0;
 }

--- a/src/network/xsan_node_comm.c
+++ b/src/network/xsan_node_comm.c
@@ -19,28 +19,40 @@
 
 #define XSAN_COMM_MAX_PEER_ADDR_LEN 64
 #define XSAN_COMM_DEFAULT_LISTEN_BACKLOG 128
-#define XSAN_COMM_SOCK_POLL_INTERVAL_US (1000)
-#define XSAN_COMM_INITIAL_RECV_BUF_SIZE (XSAN_MESSAGE_HEADER_SIZE + 4096)
+#define XSAN_COMM_SOCK_POLL_INTERVAL_US (1000) // Increased for less aggressive polling if not expecting high freq events
+#define XSAN_COMM_INITIAL_RECV_BUF_SIZE (XSAN_MESSAGE_HEADER_SIZE + 4096) // Initial buffer for header + some payload
 
+// Context for an active connection (either server-accepted or client-initiated and connected)
 typedef struct xsan_connection_ctx {
     struct spdk_sock *sock;
     char peer_addr_str[XSAN_COMM_MAX_PEER_ADDR_LEN];
 
     unsigned char *recv_buf;
     size_t recv_buf_capacity;
-    size_t recv_buf_len;
+    size_t recv_buf_len; // Current amount of data in recv_buf
     xsan_message_header_t partial_recv_header;
     bool header_fully_received;
 
+    // Generic fallback message handler for this connection (usually the global one)
     xsan_node_message_handler_cb_t app_msg_handler_cb;
     void *app_msg_handler_cb_arg;
 
+    // For an ongoing send operation
     xsan_node_send_cb_t current_send_cb;
     void* current_send_cb_arg;
 
     struct xsan_connection_ctx *next;
     struct xsan_connection_ctx *prev;
 } xsan_connection_ctx_t;
+
+// Context for an outstanding client connect operation
+typedef struct xsan_pending_connect_op {
+    xsan_node_connect_cb_t user_cb;
+    void *user_cb_arg;
+    struct spdk_sock *sock_in_progress;
+    char target_addr_str_for_log[XSAN_COMM_MAX_PEER_ADDR_LEN];
+} xsan_pending_connect_op_t;
+
 
 static struct {
     struct spdk_sock_group *sock_group_on_reactor;
@@ -50,35 +62,31 @@ static struct {
     char module_listen_ip[INET6_ADDRSTRLEN];
     uint16_t module_listen_port;
 
-    xsan_node_message_handler_cb_t global_app_msg_handler_cb;
+    xsan_node_message_handler_cb_t global_app_msg_handler_cb; // Generic fallback if no specific handler
     void *global_app_msg_handler_cb_arg;
 
     xsan_connection_ctx_t *active_connections_head;
-    pthread_mutex_t active_connections_lock;
+    pthread_mutex_t active_connections_lock; // Protects active_connections_head list
 
     bool module_initialized;
 
-    // Array for specific message handlers
     xsan_specific_message_handler_cb_t specific_handlers[XSAN_MSG_TYPE_MAX];
     void *specific_handler_args[XSAN_MSG_TYPE_MAX];
 } g_node_comm_ctx;
 
 
-// Forward declaration for the function that will handle connected client sockets
-static void _xsan_client_sock_event_callback(void *cb_arg, struct spdk_sock_group *group, struct spdk_sock *sock);
-
 static int _xsan_comm_poller_fn(void *arg);
 static void _xsan_comm_sock_event_callback(void *cb_arg, struct spdk_sock_group *group, struct spdk_sock *sock);
+static void _xsan_client_sock_event_callback(void *cb_arg, struct spdk_sock_group *group, struct spdk_sock *sock);
 static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ctx);
 static void _add_connection_to_active_list(xsan_connection_ctx_t *conn_ctx);
 static void _remove_connection_from_active_list(xsan_connection_ctx_t *conn_ctx);
 static void _cleanup_and_free_connection_ctx(xsan_connection_ctx_t *conn_ctx, bool close_spdk_sock_if_needed);
 static xsan_connection_ctx_t* _create_connection_ctx(struct spdk_sock *sock,
-                                                     xsan_node_message_handler_cb_t handler_cb,
+                                                     xsan_node_message_handler_cb_t handler_cb, // Generic handler
                                                      void *handler_cb_arg);
 static void _format_peer_addr(struct spdk_sock *sock, char *buf, size_t len);
 
-// Define XSAN_ERROR_SPDK_ENV if not present (e.g. from a previous step not fully completed)
 #ifndef XSAN_ERROR_SPDK_ENV
 #define XSAN_ERROR_SPDK_ENV XSAN_ERROR_SYSTEM
 #endif
@@ -87,25 +95,14 @@ static void _format_peer_addr(struct spdk_sock *sock, char *buf, size_t len);
 #endif
 
 
-// Context for an outstanding client connect operation
-typedef struct xsan_pending_connect_op {
-    xsan_node_connect_cb_t user_cb;
-    void *user_cb_arg;
-    struct spdk_sock *sock_in_progress; // SPDK socket being connected
-    char target_addr_str_for_log[XSAN_COMM_MAX_PEER_ADDR_LEN]; // For logging
-} xsan_pending_connect_op_t;
-
-
 xsan_error_t xsan_node_comm_init(const char *listen_ip, uint16_t listen_port,
-                                 xsan_node_message_handler_cb_t msg_handler_cb,
+                                 xsan_node_message_handler_cb_t msg_handler_cb, // Generic fallback handler
                                  void *handler_cb_arg) {
     if (g_node_comm_ctx.module_initialized) { XSAN_LOG_WARN("XSAN Comm module already init."); return XSAN_OK; }
-    // msg_handler_cb is now optional at init, if all messages will use specific handlers.
-    // if (listen_ip && !msg_handler_cb) { XSAN_LOG_WARN("Listen IP provided but no generic msg handler."); }
     if (spdk_get_thread() == NULL) { XSAN_LOG_ERROR("xsan_node_comm_init must be from SPDK thread."); return XSAN_ERROR_THREAD_CONTEXT; }
 
     XSAN_LOG_INFO("Initializing XSAN Node Comm module...");
-    memset(&g_node_comm_ctx, 0, sizeof(g_node_comm_ctx)); // This also zeros out specific_handlers array
+    memset(&g_node_comm_ctx, 0, sizeof(g_node_comm_ctx));
     if (pthread_mutex_init(&g_node_comm_ctx.active_connections_lock, NULL) != 0) { XSAN_LOG_FATAL("Mutex init failed."); return XSAN_ERROR_SYSTEM; }
 
     uint32_t current_reactor = spdk_env_get_current_core();
@@ -117,10 +114,12 @@ xsan_error_t xsan_node_comm_init(const char *listen_ip, uint16_t listen_port,
 
     if (listen_ip && listen_port > 0) {
         struct spdk_sock_opts opts; memset(&opts, 0, sizeof(opts));
-        opts.is_server = true; opts.cb_fn = _xsan_comm_sock_event_callback; opts.cb_arg = NULL;
+        opts.is_server = true;
+        opts.cb_fn = _xsan_comm_sock_event_callback; // Listener uses the main callback
+        opts.cb_arg = NULL; // Listener itself doesn't have a conn_ctx; accepted sockets will.
         opts.sock_group = g_node_comm_ctx.sock_group_on_reactor;
         g_node_comm_ctx.listener_sock = spdk_sock_listen(listen_ip, (int)listen_port, &opts);
-        if (!g_node_comm_ctx.listener_sock) { XSAN_LOG_ERROR("Failed SPDK listen on %s:%u. Errno: %d", listen_ip, listen_port, errno); pthread_mutex_destroy(&g_node_comm_ctx.active_connections_lock); return XSAN_ERROR_NETWORK; }
+        if (!g_node_comm_ctx.listener_sock) { XSAN_LOG_ERROR("Failed SPDK listen on %s:%u. Errno: %d (%s)", listen_ip, listen_port, errno, strerror(errno)); pthread_mutex_destroy(&g_node_comm_ctx.active_connections_lock); return XSAN_ERROR_NETWORK; }
         xsan_strcpy_safe(g_node_comm_ctx.module_listen_ip, listen_ip, INET6_ADDRSTRLEN);
         g_node_comm_ctx.module_listen_port = listen_port;
         XSAN_LOG_INFO("SPDK Listening socket created on %s:%u", listen_ip, listen_port);
@@ -158,7 +157,6 @@ xsan_error_t xsan_node_comm_register_message_handler(xsan_message_type_t type,
                   specific_handler ? "registered" : "unregistered", type);
     return XSAN_OK;
 }
-
 
 void xsan_node_comm_fini(void) {
     if (!g_node_comm_ctx.module_initialized) return;
@@ -211,8 +209,10 @@ static xsan_connection_ctx_t* _create_connection_ctx(struct spdk_sock *sock,
     conn_ctx->recv_buf_capacity = XSAN_COMM_INITIAL_RECV_BUF_SIZE;
     conn_ctx->recv_buf = (unsigned char *)XSAN_MALLOC(conn_ctx->recv_buf_capacity);
     if (!conn_ctx->recv_buf) { XSAN_LOG_ERROR("Failed to MALLOC recv_buf for %s.", conn_ctx->peer_addr_str); XSAN_FREE(conn_ctx); return NULL; }
-    conn_ctx->app_msg_handler_cb = handler_cb; conn_ctx->app_msg_handler_cb_arg = handler_cb_arg;
-    spdk_sock_set_cb_arg(sock, conn_ctx);
+    conn_ctx->app_msg_handler_cb = handler_cb;
+    conn_ctx->app_msg_handler_cb_arg = handler_cb_arg;
+    // DO NOT call spdk_sock_set_cb_arg here. It's done by the caller (_xsan_comm_sock_event_callback for server,
+    // or _xsan_client_sock_event_callback after successful connect for client)
     XSAN_LOG_INFO("Created connection context for peer: %s (sock %p)", conn_ctx->peer_addr_str, sock);
     return conn_ctx;
 }
@@ -243,16 +243,17 @@ static void _cleanup_and_free_connection_ctx(xsan_connection_ctx_t *conn_ctx, bo
     if (close_spdk_sock_if_needed && conn_ctx->sock) {
         struct spdk_sock *tmp_sock_ptr = conn_ctx->sock;
         XSAN_LOG_DEBUG("Calling spdk_sock_close for %s.", conn_ctx->peer_addr_str);
-        spdk_sock_close(&tmp_sock_ptr);
+        spdk_sock_close(&tmp_sock_ptr); // tmp_sock_ptr will be NULLed by spdk_sock_close
         conn_ctx->sock = NULL;
     }
     if (conn_ctx->recv_buf) { XSAN_FREE(conn_ctx->recv_buf); conn_ctx->recv_buf = NULL; }
     XSAN_FREE(conn_ctx);
 }
 
+// Generic socket event callback for established connections (server-side accepted, or client-side after connect)
 static void _xsan_comm_sock_event_callback(void *cb_arg, struct spdk_sock_group *group, struct spdk_sock *sock) {
     (void)group;
-    xsan_connection_ctx_t *conn_ctx = (xsan_connection_ctx_t *)cb_arg;
+    xsan_connection_ctx_t *conn_ctx = (xsan_connection_ctx_t *)cb_arg; // This is now always xsan_connection_ctx_t
     int event_type = spdk_sock_get_last_event_type(sock);
 
     if (sock == g_node_comm_ctx.listener_sock) {
@@ -261,6 +262,7 @@ static void _xsan_comm_sock_event_callback(void *cb_arg, struct spdk_sock_group 
             struct spdk_sock_opts opts; memset(&opts, 0, sizeof(opts));
             opts.cb_fn = _xsan_comm_sock_event_callback;
             opts.sock_group = g_node_comm_ctx.sock_group_on_reactor;
+            // opts.cb_arg will be set after _create_connection_ctx
 
             struct spdk_sock *new_data_sock = spdk_sock_accept(g_node_comm_ctx.listener_sock, &opts);
             if (new_data_sock) {
@@ -268,6 +270,7 @@ static void _xsan_comm_sock_event_callback(void *cb_arg, struct spdk_sock_group 
                                                                            g_node_comm_ctx.global_app_msg_handler_cb,
                                                                            g_node_comm_ctx.global_app_msg_handler_cb_arg);
                 if (new_conn_ctx) {
+                     spdk_sock_set_cb_arg(new_data_sock, new_conn_ctx);
                     _add_connection_to_active_list(new_conn_ctx);
                 } else {
                     XSAN_LOG_ERROR("Failed to create conn_ctx for accepted socket. Closing.");
@@ -279,7 +282,7 @@ static void _xsan_comm_sock_event_callback(void *cb_arg, struct spdk_sock_group 
     }
 
     if (!conn_ctx) {
-        XSAN_LOG_ERROR("Socket event for sock %p with NULL conn_ctx! This is a bug.", sock);
+        XSAN_LOG_ERROR("Socket event for non-listener sock %p with NULL conn_ctx! This is a bug.", sock);
         return;
     }
 
@@ -318,10 +321,10 @@ static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ct
             size_t new_capacity = conn_ctx->recv_buf_capacity > 0 ? conn_ctx->recv_buf_capacity * 2 : XSAN_COMM_INITIAL_RECV_BUF_SIZE;
             if (new_capacity > (XSAN_PROTOCOL_MAX_PAYLOAD_SIZE + XSAN_MESSAGE_HEADER_SIZE + 4096)) {
                  XSAN_LOG_ERROR("Receive buffer for %s reached excessive size %zu. Closing.", conn_ctx->peer_addr_str, new_capacity);
-                 goto close_conn_error_proc;
+                 goto close_conn_error_proc_recv;
             }
             unsigned char *new_buf = (unsigned char *)XSAN_REALLOC(conn_ctx->recv_buf, new_capacity);
-            if (!new_buf) { XSAN_LOG_ERROR("Failed to realloc recv_buf for %s. Closing.", conn_ctx->peer_addr_str); goto close_conn_error_proc; }
+            if (!new_buf) { XSAN_LOG_ERROR("Failed to realloc recv_buf for %s. Closing.", conn_ctx->peer_addr_str); goto close_conn_error_proc_recv; }
             conn_ctx->recv_buf = new_buf; conn_ctx->recv_buf_capacity = new_capacity;
         }
 
@@ -337,9 +340,9 @@ static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ct
                 if (!conn_ctx->header_fully_received) {
                     if (conn_ctx->recv_buf_len >= XSAN_MESSAGE_HEADER_SIZE) {
                         xsan_error_t err_hdr = xsan_protocol_header_deserialize(conn_ctx->recv_buf, &conn_ctx->partial_recv_header);
-                        if (err_hdr != XSAN_OK) { XSAN_LOG_ERROR("Header deserialize failed from %s: %s. Closing.", conn_ctx->peer_addr_str, xsan_error_string(err_hdr)); goto close_conn_error_proc;}
-                        if (conn_ctx->partial_recv_header.magic != XSAN_PROTOCOL_MAGIC) { XSAN_LOG_ERROR("Bad magic 0x%x from %s. Closing.", conn_ctx->partial_recv_header.magic, conn_ctx->peer_addr_str); goto close_conn_error_proc;}
-                        if (conn_ctx->partial_recv_header.payload_length > XSAN_PROTOCOL_MAX_PAYLOAD_SIZE) { XSAN_LOG_ERROR("Payload %u too large from %s. Closing.", conn_ctx->partial_recv_header.payload_length, conn_ctx->peer_addr_str); goto close_conn_error_proc;}
+                        if (err_hdr != XSAN_OK) { XSAN_LOG_ERROR("Header deserialize failed from %s: %s. Closing.", conn_ctx->peer_addr_str, xsan_error_string(err_hdr)); goto close_conn_error_proc_recv;}
+                        if (conn_ctx->partial_recv_header.magic != XSAN_PROTOCOL_MAGIC) { XSAN_LOG_ERROR("Bad magic 0x%x from %s. Closing.", conn_ctx->partial_recv_header.magic, conn_ctx->peer_addr_str); goto close_conn_error_proc_recv;}
+                        if (conn_ctx->partial_recv_header.payload_length > XSAN_PROTOCOL_MAX_PAYLOAD_SIZE) { XSAN_LOG_ERROR("Payload %u too large from %s. Closing.", conn_ctx->partial_recv_header.payload_length, conn_ctx->peer_addr_str); goto close_conn_error_proc_recv;}
 
                         conn_ctx->header_fully_received = true;
                         memmove(conn_ctx->recv_buf, conn_ctx->recv_buf + XSAN_MESSAGE_HEADER_SIZE, conn_ctx->recv_buf_len - XSAN_MESSAGE_HEADER_SIZE);
@@ -351,12 +354,12 @@ static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ct
                 if (conn_ctx->header_fully_received) {
                     if (conn_ctx->recv_buf_len >= conn_ctx->partial_recv_header.payload_length) {
                         xsan_message_t *full_msg = (xsan_message_t*)XSAN_MALLOC(sizeof(xsan_message_t));
-                        if (!full_msg) { XSAN_LOG_ERROR("OOM for xsan_message_t from %s. Closing.", conn_ctx->peer_addr_str); goto close_conn_error_proc; }
+                        if (!full_msg) { XSAN_LOG_ERROR("OOM for xsan_message_t from %s. Closing.", conn_ctx->peer_addr_str); goto close_conn_error_proc_recv; }
 
                         memcpy(&full_msg->header, &conn_ctx->partial_recv_header, sizeof(xsan_message_header_t));
                         if (full_msg->header.payload_length > 0) {
                             full_msg->payload = (unsigned char *)XSAN_MALLOC(full_msg->header.payload_length);
-                            if (!full_msg->payload) { XSAN_LOG_ERROR("OOM for payload from %s. Closing.", conn_ctx->peer_addr_str); XSAN_FREE(full_msg); goto close_conn_error_proc; }
+                            if (!full_msg->payload) { XSAN_LOG_ERROR("OOM for payload from %s. Closing.", conn_ctx->peer_addr_str); XSAN_FREE(full_msg); goto close_conn_error_proc_recv; }
                             memcpy(full_msg->payload, conn_ctx->recv_buf, full_msg->header.payload_length);
                         } else full_msg->payload = NULL;
 
@@ -366,9 +369,8 @@ static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ct
                         xsan_message_type_t msg_type = (xsan_message_type_t)full_msg->header.type;
                         if (msg_type > XSAN_MSG_TYPE_UNDEFINED && msg_type < XSAN_MSG_TYPE_MAX &&
                             g_node_comm_ctx.specific_handlers[msg_type] != NULL) {
-                            // Pass conn_ctx instead of sock and peer_addr_str directly
                             g_node_comm_ctx.specific_handlers[msg_type](conn_ctx, full_msg, g_node_comm_ctx.specific_handler_args[msg_type]);
-                        } else if (conn_ctx->app_msg_handler_cb) { // Fallback to global/connection-specific generic handler
+                        } else if (conn_ctx->app_msg_handler_cb) {
                             XSAN_LOG_WARN("No specific handler for msg type %u from %s. Using generic handler.", msg_type, conn_ctx->peer_addr_str);
                             conn_ctx->app_msg_handler_cb(conn_ctx->sock, conn_ctx->peer_addr_str, full_msg, conn_ctx->app_msg_handler_cb_arg);
                         } else {
@@ -389,34 +391,22 @@ static void _process_received_data_for_connection(xsan_connection_ctx_t *conn_ct
             return;
         } else {
             if (errno == EAGAIN || errno == EWOULDBLOCK) { /* No more data now */ }
-            else { XSAN_LOG_ERROR("spdk_sock_recv error on %s: %d (%s). Closing.", conn_ctx->peer_addr_str, errno, strerror(errno)); goto close_conn_error_proc; }
+            else { XSAN_LOG_ERROR("spdk_sock_recv error on %s: %d (%s). Closing.", conn_ctx->peer_addr_str, errno, strerror(errno)); goto close_conn_error_proc_recv; }
             return;
         }
-    } while (nbytes > 0 && conn_ctx->sock); // Loop if we read something and socket still valid
+    } while (nbytes > 0 && conn_ctx->sock);
     return;
 
-close_conn_error_proc:
+close_conn_error_proc_recv:
     _remove_connection_from_active_list(conn_ctx);
     _cleanup_and_free_connection_ctx(conn_ctx, true);
 }
-
-// --- Client and Data Transfer Operations ---
-
-// Context for an outstanding client connect operation
-typedef struct xsan_pending_connect_op {
-    xsan_node_connect_cb_t user_cb;
-    void *user_cb_arg;
-    struct spdk_sock *sock_in_progress; // SPDK socket being connected
-    // Store target info for logging in callback if needed
-    // char target_addr_str[XSAN_COMM_MAX_PEER_ADDR_LEN];
-} xsan_pending_connect_op_t;
-
 
 xsan_error_t xsan_node_comm_connect(const char *target_ip, uint16_t target_port,
                                     xsan_node_connect_cb_t connect_cb, void *cb_arg) {
     if (!g_node_comm_ctx.module_initialized) {
         XSAN_LOG_ERROR("Node comm module not initialized for connect.");
-        return XSAN_ERROR_INVALID_STATE; // Define this error
+        return XSAN_ERROR_INVALID_STATE;
     }
     if (!target_ip || target_port == 0 || !connect_cb) {
         return XSAN_ERROR_INVALID_PARAM;
@@ -436,32 +426,78 @@ xsan_error_t xsan_node_comm_connect(const char *target_ip, uint16_t target_port,
     }
     pending_op->user_cb = connect_cb;
     pending_op->user_cb_arg = cb_arg;
-    // snprintf(pending_op->target_addr_str, XSAN_COMM_MAX_PEER_ADDR_LEN, "%s:%u", target_ip, target_port);
+    xsan_snprintf_safe(pending_op->target_addr_str_for_log, XSAN_COMM_MAX_PEER_ADDR_LEN, "%s:%u", target_ip, target_port);
 
     struct spdk_sock_opts opts;
     memset(&opts, 0, sizeof(opts));
     opts.is_server = false;
-    opts.cb_fn = _xsan_comm_sock_event_callback; // All events go here
-    opts.cb_arg = pending_op; // Initially, cb_arg is the pending_op context
+    opts.cb_fn = _xsan_client_sock_event_callback;
+    opts.cb_arg = pending_op;
     opts.sock_group = g_node_comm_ctx.sock_group_on_reactor;
 
     pending_op->sock_in_progress = spdk_sock_connect(target_ip, (int)target_port, &opts);
     if (!pending_op->sock_in_progress) {
         int err_no = errno;
-        XSAN_LOG_ERROR("spdk_sock_connect call failed immediately for %s:%u. Errno: %d (%s)",
-                       target_ip, target_port, err_no, strerror(err_no));
+        XSAN_LOG_ERROR("spdk_sock_connect call failed immediately for %s. Errno: %d (%s)",
+                       pending_op->target_addr_str_for_log, err_no, strerror(err_no));
         XSAN_FREE(pending_op);
-        // Call user callback with failure directly
-        connect_cb(NULL, -err_no, cb_arg); // Pass negative errno
+        connect_cb(NULL, -err_no, cb_arg);
         return xsan_error_from_errno(err_no);
     }
 
-    // If spdk_sock_connect returns a socket, the connect is in progress.
-    // The cb_arg for the socket (pending_op->sock_in_progress) is already set to pending_op via opts.cb_arg.
-    // The _xsan_comm_sock_event_callback will handle SPDK_SOCK_EVENT_CONNECTED or error events.
-    XSAN_LOG_DEBUG("SPDK connect initiated for %s:%u, temp sock %p, cb_arg (pending_op) %p",
-                   target_ip, target_port, pending_op->sock_in_progress, pending_op);
+    XSAN_LOG_DEBUG("SPDK connect initiated for %s, client sock %p, cb_arg (pending_op) %p",
+                   pending_op->target_addr_str_for_log, pending_op->sock_in_progress, pending_op);
     return XSAN_OK;
+}
+
+static void _xsan_client_sock_event_callback(void *cb_arg, struct spdk_sock_group *group, struct spdk_sock *sock) {
+    (void)group; // Usually not needed if all sockets in the same group
+    xsan_pending_connect_op_t *pending_op = (xsan_pending_connect_op_t *)cb_arg;
+    int event_type = spdk_sock_get_last_event_type(sock);
+    int s_errno = spdk_sock_get_error(sock);
+
+    if (!pending_op || pending_op->sock_in_progress != sock) {
+        XSAN_LOG_ERROR("Client socket event for sock %p with mismatched/NULL pending_op! This is a bug.", sock);
+        if (sock) { struct spdk_sock *tmp_sock = sock; spdk_sock_close(&tmp_sock); }
+        if (pending_op) XSAN_FREE(pending_op);
+        return;
+    }
+
+    XSAN_LOG_DEBUG("Client socket event for %s (sock %p), type %d, sock_errno: %d",
+                   pending_op->target_addr_str_for_log, sock, event_type, s_errno);
+
+    switch (event_type) {
+        case SPDK_SOCK_EVENT_CONNECTED: {
+            XSAN_LOG_INFO("Successfully connected to %s (sock %p).", pending_op->target_addr_str_for_log, sock);
+            xsan_connection_ctx_t *new_conn_ctx = _create_connection_ctx(sock,
+                                                                       g_node_comm_ctx.global_app_msg_handler_cb,
+                                                                       g_node_comm_ctx.global_app_msg_handler_cb_arg);
+            if (new_conn_ctx) {
+                _add_connection_to_active_list(new_conn_ctx);
+                spdk_sock_set_cb_fn(sock, _xsan_comm_sock_event_callback);
+                spdk_sock_set_cb_arg(sock, new_conn_ctx);
+                pending_op->user_cb(sock, 0, pending_op->user_cb_arg);
+            } else {
+                XSAN_LOG_ERROR("Failed to create conn_ctx for successfully connected client socket %s. Closing.", pending_op->target_addr_str_for_log);
+                pending_op->user_cb(NULL, -ENOMEM, pending_op->user_cb_arg);
+                struct spdk_sock *tmp_sock = sock; spdk_sock_close(&tmp_sock);
+            }
+            XSAN_FREE(pending_op);
+            break;
+        }
+        case SPDK_SOCK_EVENT_ERR:
+        case SPDK_SOCK_EVENT_HUP:
+            XSAN_LOG_ERROR("Failed to connect to %s (sock %p). Event: %d, errno: %d (%s), sock_errno: %d",
+                          pending_op->target_addr_str_for_log, sock, event_type, errno, strerror(errno), s_errno);
+            pending_op->user_cb(NULL, s_errno ? -s_errno : -ECONNREFUSED, pending_op->user_cb_arg);
+            pending_op->sock_in_progress = NULL;
+            XSAN_FREE(pending_op);
+            // SPDK usually closes the socket on error during connect.
+            break;
+        default:
+            XSAN_LOG_WARN("Unexpected event %d on client socket %s during connection phase.", event_type, pending_op->target_addr_str_for_log);
+            break;
+    }
 }
 
 xsan_error_t xsan_node_comm_send_msg(struct spdk_sock *sock, xsan_message_t *msg,
@@ -471,7 +507,7 @@ xsan_error_t xsan_node_comm_send_msg(struct spdk_sock *sock, xsan_message_t *msg
     if (spdk_get_thread() == NULL) { XSAN_LOG_ERROR("send_msg must be from SPDK thread."); return XSAN_ERROR_THREAD_CONTEXT; }
 
     xsan_connection_ctx_t *conn_ctx = (xsan_connection_ctx_t *)spdk_sock_get_cb_arg(sock);
-    if (!conn_ctx || conn_ctx->sock != sock) { // Basic validation
+    if (!conn_ctx || conn_ctx->sock != sock) {
         XSAN_LOG_ERROR("No valid XSAN connection context found for sock %p during send_msg.", sock);
         return XSAN_ERROR_INVALID_PARAM;
     }
@@ -505,7 +541,7 @@ xsan_error_t xsan_node_comm_send_msg(struct spdk_sock *sock, xsan_message_t *msg
     ssize_t bytes_written = spdk_sock_writev(sock, iov, iovcnt);
 
     if (bytes_written < 0) {
-        int err_no = errno; // spdk_sock_writev returns positive bytes_written or negative errno
+        int err_no = errno;
         XSAN_LOG_ERROR("spdk_sock_writev failed for %s: %d (%s)", conn_ctx->peer_addr_str, err_no, strerror(err_no));
         if (send_cb) send_cb(-err_no, cb_arg);
         return xsan_error_from_errno(err_no);
@@ -514,20 +550,14 @@ xsan_error_t xsan_node_comm_send_msg(struct spdk_sock *sock, xsan_message_t *msg
     if ((size_t)bytes_written < total_to_send) {
         XSAN_LOG_WARN("Partial write to %s: %zd sent, %zu total. Full async send logic with queueing needed for this case.",
                       conn_ctx->peer_addr_str, bytes_written, total_to_send);
-        // For this simplified version, if a partial write happens and SPDK doesn't buffer and retry,
-        // this is effectively an error or requires more complex handling.
-        // Store the callback to be invoked on SPDK_SOCK_EVENT_WRITE_COMPLETE if SPDK signals it.
         conn_ctx->current_send_cb = send_cb;
         conn_ctx->current_send_cb_arg = cb_arg;
-        // SPDK should call the socket cb with SPDK_SOCK_EVENT_WRITE_COMPLETE when more data can be sent.
-        // Our _xsan_comm_sock_event_callback will then call the user's send_cb.
-        // We return OK because the operation is now "in progress" from SPDK's view.
         return XSAN_OK;
     }
 
     XSAN_LOG_DEBUG("Successfully wrote all %zd bytes to %s.", bytes_written, conn_ctx->peer_addr_str);
     if (send_cb) {
-        send_cb(0, cb_arg); // Notify success (all data accepted by socket buffer)
+        send_cb(0, cb_arg);
     }
     return XSAN_OK;
 }
@@ -547,21 +577,15 @@ void xsan_node_comm_disconnect(struct spdk_sock **sock_ptr) {
         iter = iter->next;
     }
     if(conn_ctx) {
-        // Remove from list first to prevent further operations on it via list traversal
         _remove_connection_from_active_list(conn_ctx);
     }
     pthread_mutex_unlock(&g_node_comm_ctx.active_connections_lock);
 
     if(conn_ctx) {
-        // This will call spdk_sock_close if the socket is still valid in conn_ctx
         _cleanup_and_free_connection_ctx(conn_ctx, true);
     } else {
-        // If no context was found, but we have a socket pointer, try to close it directly.
-        // This might happen if the socket was never fully added (e.g. connect error before ctx creation)
-        // or if disconnect is called multiple times.
         XSAN_LOG_WARN("Disconnecting socket %p that had no XSAN connection context. Closing directly.", *sock_ptr);
-        spdk_sock_close(sock_ptr); // This will set *sock_ptr to NULL
+        spdk_sock_close(sock_ptr);
     }
-    // Ensure caller's pointer is NULL if spdk_sock_close didn't do it (it should)
     if (sock_ptr) *sock_ptr = NULL;
 }

--- a/src/nvmf/CMakeLists.txt
+++ b/src/nvmf/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_library(xsan_nvmf_target STATIC
+    xsan_nvmf_target.c
+)
+
+# Public include directories needed by code that uses this library's headers
+target_include_directories(xsan_nvmf_target PUBLIC
+    ${CMAKE_SOURCE_DIR}/include      # For xsan_types.h, xsan_error.h
+    ${CMAKE_SOURCE_DIR}/src/include  # For xsan_nvmf_target.h
+)
+
+# Dependencies for xsan_nvmf_target library itself
+target_link_libraries(xsan_nvmf_target PUBLIC
+    xsan_common     # For xsan_error_t
+    xsan_utils      # For XSAN_LOG_*, XSAN_STRDUP (if used)
+    # SPDK libraries are linked at the executable level.
+    # However, this module directly calls SPDK NVMe-oF and bdev APIs.
+    # The necessary SPDK headers (nvmf.h, bdev.h, thread.h, env.h) should be globally available.
+    # Linking against specific SPDK components might be needed if not handled by XSAN_SPDK_LIBRARIES.
+    # For example: spdk_nvmf, spdk_bdev, spdk_thread, spdk_env_dpdk
+    # We rely on XSAN_SPDK_LIBRARIES from the root CMakeLists.txt to cover these.
+)
+
+message(STATUS "XSAN NVMe-oF Target module (xsan_nvmf_target.c) configured.")

--- a/src/nvmf/xsan_nvmf_target.c
+++ b/src/nvmf/xsan_nvmf_target.c
@@ -1,0 +1,268 @@
+#include "xsan_nvmf_target.h"
+#include "xsan_log.h"
+#include "xsan_error.h"
+#include "xsan_memory.h" // For XSAN_STRDUP if needed for NQN copy
+
+#include "spdk/stdinc.h"
+#include "spdk/env.h"
+#include "spdk/thread.h"
+#include "spdk/nvmf.h"
+#include "spdk/nvmf_spec.h" // For spdk_nvmf_subsystem_set_allow_any_host
+#include "spdk/bdev.h"     // For spdk_bdev_get_by_name
+
+// Define a default NQN if none is provided.
+// Format: nqn.2016-06.io.spdk:xsan-target
+#define XSAN_DEFAULT_NVMF_NQN_PREFIX "nqn.2024-01.org.xsan:"
+#define XSAN_DEFAULT_NVMF_SUBSYSTEM_SERIAL "XSAN000000000001"
+#define XSAN_DEFAULT_NVMF_SUBSYSTEM_MODEL "XSAN Virtual Controller"
+
+// Global context for this module (simplified for now)
+static struct spdk_nvmf_tgt *g_xsan_nvmf_tgt = NULL;
+static struct spdk_nvmf_subsystem *g_xsan_default_subsystem = NULL;
+// We might support multiple transports, but TCP is common for initial setup.
+// static struct spdk_nvmf_transport *g_xsan_tcp_transport = NULL;
+
+// Store NQN to avoid issues with string lifetime if passed NQN is on stack
+static char g_target_nqn_storage[SPDK_NVMF_NQN_MAX_LEN + 1];
+
+
+xsan_error_t xsan_nvmf_target_init(const char *target_nqn_param,
+                                   const char *listen_addr,
+                                   const char *listen_port_str) {
+    if (g_xsan_nvmf_tgt) {
+        XSAN_LOG_WARN("XSAN NVMe-oF Target already initialized.");
+        return XSAN_OK;
+    }
+    if (spdk_get_thread() == NULL) {
+        XSAN_LOG_ERROR("NVMe-oF Target init must be called from an SPDK thread.");
+        return XSAN_ERROR_THREAD_CONTEXT;
+    }
+    if (!listen_addr || !listen_port_str) {
+        XSAN_LOG_ERROR("Listen address and port must be provided for NVMe-oF Target init.");
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    XSAN_LOG_INFO("Initializing XSAN NVMe-oF Target...");
+
+    int rc = 0;
+    const char *used_nqn = target_nqn_param;
+
+    if (!used_nqn || strlen(used_nqn) == 0) {
+        // Generate a default NQN if not provided
+        snprintf(g_target_nqn_storage, sizeof(g_target_nqn_storage), "%stgt1", XSAN_DEFAULT_NVMF_NQN_PREFIX);
+        used_nqn = g_target_nqn_storage;
+        XSAN_LOG_INFO("No NQN provided, using default: %s", used_nqn);
+    } else {
+        // Copy the provided NQN in case it's a temporary string
+        strncpy(g_target_nqn_storage, target_nqn_param, SPDK_NVMF_NQN_MAX_LEN);
+        g_target_nqn_storage[SPDK_NVMF_NQN_MAX_LEN] = '\0'; // Ensure null termination
+        used_nqn = g_target_nqn_storage;
+    }
+
+
+    // 1. Create an NVMe-oF Target
+    // Max subsystems can be configured via spdk_nvmf_tgt_opts if needed. Default is usually fine.
+    g_xsan_nvmf_tgt = spdk_nvmf_tgt_create(NULL); // Use default opts
+    if (!g_xsan_nvmf_tgt) {
+        XSAN_LOG_ERROR("spdk_nvmf_tgt_create() failed.");
+        return XSAN_ERROR_SPDK_API; // Define this error
+    }
+
+    // 2. Create and configure the TCP transport (common default)
+    // Transport specific opts can be set in struct spdk_nvmf_transport_opts
+    struct spdk_nvmf_transport_opts transport_opts;
+    spdk_nvmf_transport_opts_init("TCP", &transport_opts, sizeof(transport_opts));
+    // transport_opts.io_unit_size = 8192; // Example: Set IO unit size for this transport
+    // transport_opts.max_queue_depth = 128; // Example
+
+    struct spdk_nvmf_transport *tcp_transport = spdk_nvmf_transport_create("TCP", &transport_opts);
+    if (!tcp_transport) {
+        XSAN_LOG_ERROR("spdk_nvmf_transport_create('TCP') failed.");
+        spdk_nvmf_tgt_destroy(g_xsan_nvmf_tgt);
+        g_xsan_nvmf_tgt = NULL;
+        return XSAN_ERROR_SPDK_API;
+    }
+    // g_xsan_tcp_transport = tcp_transport; // Store if needed for specific operations later
+
+    // 3. Create a default NVMf Subsystem
+    // A subsystem is what an initiator discovers and connects to.
+    g_xsan_default_subsystem = spdk_nvmf_subsystem_create(g_xsan_nvmf_tgt, used_nqn,
+                                                          SPDK_NVMF_SUBTYPE_NVME, // or SPDK_NVMF_SUBTYPE_DISCOVERY
+                                                          1); // Number of NS, can be increased dynamically
+    if (!g_xsan_default_subsystem) {
+        XSAN_LOG_ERROR("spdk_nvmf_subsystem_create() failed for NQN %s.", used_nqn);
+        // spdk_nvmf_transport_destroy(tcp_transport); // How to get this handle back if not stored globally?
+        // Need a way to iterate and destroy transports if tgt_destroy doesn't do it.
+        // For now, assume tgt_destroy cleans up transports created for it if not explicitly destroyed.
+        // Better: SPDK examples show transports are usually created and then passed to tgt_listen.
+        // The target doesn't "own" transports created this way directly.
+        // Let's defer transport destruction to fini.
+        spdk_nvmf_tgt_destroy(g_xsan_nvmf_tgt);
+        g_xsan_nvmf_tgt = NULL;
+        return XSAN_ERROR_SPDK_API;
+    }
+
+    // Configure the subsystem (e.g., allow any host to connect for simplicity)
+    spdk_nvmf_subsystem_set_allow_any_host(g_xsan_default_subsystem, true);
+
+    // Set serial number and model number for the subsystem (good practice)
+    rc = spdk_nvmf_subsystem_set_sn(g_xsan_default_subsystem, XSAN_DEFAULT_NVMF_SUBSYSTEM_SERIAL);
+    if (rc != 0) {
+        XSAN_LOG_WARN("Failed to set subsystem serial number for NQN %s: %s", used_nqn, spdk_strerror(-rc));
+    }
+    rc = spdk_nvmf_subsystem_set_mn(g_xsan_default_subsystem, XSAN_DEFAULT_NVMF_SUBSYSTEM_MODEL);
+     if (rc != 0) {
+        XSAN_LOG_WARN("Failed to set subsystem model number for NQN %s: %s", used_nqn, spdk_strerror(-rc));
+    }
+
+
+    // 4. Add a listener for the subsystem on the TCP transport
+    struct spdk_nvmf_listen_addr listen_saddr; // Changed from spdk_nvme_transport_id
+    memset(&listen_saddr, 0, sizeof(listen_saddr));
+    listen_saddr.trtype = SPDK_NVMF_TRTYPE_TCP; // Explicitly TCP
+    xsan_strcpy_safe(listen_saddr.traddr, listen_addr, sizeof(listen_saddr.traddr));
+    xsan_strcpy_safe(listen_saddr.trsvcid, listen_port_str, sizeof(listen_saddr.trsvcid));
+
+    rc = spdk_nvmf_subsystem_add_listener(g_xsan_default_subsystem, &listen_saddr);
+    if (rc != 0) {
+        XSAN_LOG_ERROR("spdk_nvmf_subsystem_add_listener() failed for NQN %s on %s:%s : %s",
+                       used_nqn, listen_addr, listen_port_str, spdk_strerror(-rc));
+        spdk_nvmf_subsystem_destroy(g_xsan_default_subsystem, NULL, NULL); //Requires callback, or direct destroy
+        g_xsan_default_subsystem = NULL;
+        spdk_nvmf_tgt_destroy(g_xsan_nvmf_tgt);
+        g_xsan_nvmf_tgt = NULL;
+        // Transport cleanup might be needed too
+        return XSAN_ERROR_SPDK_API;
+    }
+    XSAN_LOG_INFO("NVMe-oF Target listening on %s (IP: %s, Port: %s) for NQN: %s",
+                  "TCP", listen_addr, listen_port_str, used_nqn);
+
+    // 5. Start the subsystem (makes it available for discovery and connection)
+    // Subsystems are started asynchronously. The callback is optional.
+    rc = spdk_nvmf_subsystem_start(g_xsan_default_subsystem, NULL, NULL);
+    if (rc != 0) {
+         XSAN_LOG_ERROR("spdk_nvmf_subsystem_start() failed for NQN %s: %s", used_nqn, spdk_strerror(-rc));
+        // Complex cleanup needed here as listener might be active
+        // For simplicity, we might leak some resources on this specific error path
+        // or rely on higher level fini to clean up.
+        return XSAN_ERROR_SPDK_API;
+    }
+
+    XSAN_LOG_INFO("XSAN NVMe-oF Target initialized and default subsystem NQN '%s' started.", used_nqn);
+    return XSAN_OK;
+}
+
+void xsan_nvmf_target_fini(void) {
+    if (!g_xsan_nvmf_tgt) {
+        XSAN_LOG_DEBUG("XSAN NVMe-oF Target already finalized or not initialized.");
+        return;
+    }
+    XSAN_LOG_INFO("Finalizing XSAN NVMe-oF Target...");
+
+    // Subsystems (and their namespaces, listeners) should be destroyed before the target.
+    // SPDK's spdk_nvmf_tgt_destroy is supposed to clean up its subsystems.
+    // If we created subsystems separately and need specific cleanup for them:
+    if (g_xsan_default_subsystem) {
+        // To stop it if subsystem_destroy doesn't imply stop:
+        // spdk_nvmf_subsystem_stop(g_xsan_default_subsystem, NULL, NULL); // Async, wait if needed
+        // spdk_nvmf_subsystem_set_state(g_xsan_default_subsystem, SPDK_NVMF_SUBSYSTEM_STATE_INACTIVE);
+        // spdk_nvmf_subsystem_pause(g_xsan_default_subsystem, NULL, NULL);
+
+        // Destroying the subsystem should also remove its listeners and namespaces.
+        // The spdk_nvmf_subsystem_destroy is asynchronous.
+        // For a synchronous-like fini, one might need to use the callback or poll.
+        // For simplicity in this example, we call destroy.
+        // Proper shutdown might involve spdk_nvmf_subsystem_stop() first.
+        // Let's assume tgt_destroy handles subsystems correctly.
+        XSAN_LOG_DEBUG("Default subsystem NQN %s will be destroyed by tgt_destroy.", spdk_nvmf_subsystem_get_nqn(g_xsan_default_subsystem));
+        g_xsan_default_subsystem = NULL; // tgt_destroy should handle it.
+    }
+
+    spdk_nvmf_tgt_destroy(g_xsan_nvmf_tgt, NULL, NULL); // Also async.
+    g_xsan_nvmf_tgt = NULL;
+
+    // Transports are typically managed globally by SPDK after creation
+    // and might be destroyed via spdk_nvmf_transport_destroy if we have the handle
+    // or during spdk_app_fini. For transports created with opts and passed to tgt_listen,
+    // they are often managed by the target.
+    // If we called spdk_nvmf_transport_create, we should call spdk_nvmf_transport_destroy.
+    // Let's assume for now that spdk_app_fini or tgt_destroy handles transports if not explicitly.
+    // This needs verification against SPDK examples for the specific transport creation method.
+    // If spdk_nvmf_transport_create was used, we need to destroy it:
+    // struct spdk_nvmf_transport *tcp_transport = spdk_nvmf_get_transport("TCP");
+    // if (tcp_transport) {
+    //     spdk_nvmf_transport_destroy(tcp_transport, NULL, NULL);
+    // }
+    // However, getting it by name might not be safe if multiple exist or if it was already cleaned.
+    // Better to store g_xsan_tcp_transport if we create it.
+    // For now, relying on SPDK's higher-level cleanup (spdk_app_fini).
+
+    XSAN_LOG_INFO("XSAN NVMe-oF Target finalized.");
+}
+
+xsan_error_t xsan_nvmf_target_add_namespace(const char *bdev_name, uint32_t nsid, const char *volume_uuid_str) {
+    // STUB
+    XSAN_LOG_WARN("xsan_nvmf_target_add_namespace for bdev '%s' (NSID %u) - STUB", bdev_name, nsid);
+    if (!g_xsan_nvmf_tgt || !g_xsan_default_subsystem) {
+        XSAN_LOG_ERROR("NVMe-oF target or default subsystem not initialized.");
+        return XSAN_ERROR_NOT_INITIALIZED;
+    }
+    if (!bdev_name || bdev_name[0] == '\0') {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    struct spdk_bdev *bdev = spdk_bdev_get_by_name(bdev_name);
+    if (!bdev) {
+        XSAN_LOG_ERROR("Bdev '%s' not found to add as NVMe-oF namespace.", bdev_name);
+        return XSAN_ERROR_NOT_FOUND;
+    }
+
+    struct spdk_nvmf_ns_opts ns_opts;
+    spdk_nvmf_ns_opts_get_defaults(&ns_opts, sizeof(ns_opts));
+    if (nsid > 0) { // If 0, SPDK assigns next available. If >0, user requests specific.
+        ns_opts.nsid = nsid;
+    }
+    if (volume_uuid_str && strlen(volume_uuid_str) > 0) {
+        if (spdk_uuid_parse(&ns_opts.uuid, volume_uuid_str) != 0) {
+            XSAN_LOG_WARN("Failed to parse provided volume UUID string '%s' for namespace. Namespace will get a generated UUID.", volume_uuid_str);
+            // ns_opts.uuid will remain zeroed, SPDK will generate one.
+        } else {
+             char parsed_uuid_char[SPDK_UUID_STRING_LEN];
+             spdk_uuid_fmt_lower(parsed_uuid_char, sizeof(parsed_uuid_char), &ns_opts.uuid);
+             XSAN_LOG_INFO("Using provided UUID %s for NVMe-oF namespace for bdev %s", parsed_uuid_char, bdev_name);
+        }
+    }
+    // Can also set NGUID (ns_opts.nguid) if needed.
+
+    uint32_t actual_nsid = spdk_nvmf_subsystem_add_ns(g_xsan_default_subsystem, bdev, &ns_opts);
+    if (actual_nsid == 0) { // spdk_nvmf_subsystem_add_ns returns 0 on failure, or the assigned NSID on success.
+        XSAN_LOG_ERROR("spdk_nvmf_subsystem_add_ns() failed for bdev '%s' on NQN %s.",
+                       bdev_name, spdk_nvmf_subsystem_get_nqn(g_xsan_default_subsystem));
+        return XSAN_ERROR_SPDK_API;
+    }
+
+    XSAN_LOG_INFO("Namespace (NSID: %u) added for bdev '%s' to subsystem NQN '%s'.",
+                  actual_nsid, bdev_name, spdk_nvmf_subsystem_get_nqn(g_xsan_default_subsystem));
+    return XSAN_OK;
+}
+
+xsan_error_t xsan_nvmf_target_remove_namespace(uint32_t nsid) {
+    if (!g_xsan_nvmf_tgt || !g_xsan_default_subsystem) {
+        XSAN_LOG_ERROR("NVMe-oF target or default subsystem not initialized for ns remove.");
+        return XSAN_ERROR_NOT_INITIALIZED;
+    }
+    if (nsid == 0) { // Invalid NSID
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    int rc = spdk_nvmf_subsystem_remove_ns(g_xsan_default_subsystem, nsid);
+    if (rc != 0) {
+        XSAN_LOG_ERROR("spdk_nvmf_subsystem_remove_ns() failed for NSID %u on NQN %s: %s",
+                       nsid, spdk_nvmf_subsystem_get_nqn(g_xsan_default_subsystem), spdk_strerror(-rc));
+        return XSAN_ERROR_SPDK_API;
+    }
+
+    XSAN_LOG_INFO("Namespace (NSID: %u) removed from subsystem NQN '%s'.",
+                  nsid, spdk_nvmf_subsystem_get_nqn(g_xsan_default_subsystem));
+    return XSAN_OK;
+}

--- a/src/replication/CMakeLists.txt
+++ b/src/replication/CMakeLists.txt
@@ -1,24 +1,23 @@
 add_library(xsan_replication STATIC
+    xsan_replication.c # Added: contains context create/free functions
     xsan_replication_common.c
     # Add other .c files from src/replication/ here in the future
     # e.g., xsan_replication_manager.c, xsan_replica_placement.c
 )
 
 # Public include directories needed by code that uses this library's headers
-# (e.g., if xsan_storage includes xsan_replication.h)
 target_include_directories(xsan_replication PUBLIC
     ${CMAKE_SOURCE_DIR}/include      # For xsan_types.h, xsan_storage.h etc.
     ${CMAKE_SOURCE_DIR}/src/include  # For xsan_replication.h, xsan_io.h etc.
 )
 
 # Dependencies for xsan_replication library itself.
-# These are other XSAN static libraries that xsan_replication_common.c might use.
 target_link_libraries(xsan_replication PUBLIC
-    xsan_common     # For xsan_error_t, potentially data structures if not using xsan_list directly
-    xsan_utils      # For XSAN_MALLOC, XSAN_LOG_*
-    xsan_io         # xsan_replicated_io_ctx_t contains xsan_io_request_t*
-    # xsan_list     # If xsan_list is a separate target and used directly here.
-                    # Currently, xsan_replicated_io_ctx_t doesn't directly use xsan_list.
+    xsan_common     # For xsan_error_t
+    xsan_utils      # For XSAN_MALLOC, XSAN_LOG_*, xsan_strdup
+    xsan_io         # For xsan_io_request_t in headers
+    xsan_bdev       # For xsan_bdev_dma_free
+    xsan_protocol   # For xsan_protocol_message_destroy
 )
 
 # SPDK includes are handled globally by the root CMakeLists.txt.

--- a/src/replication/xsan_replication.c
+++ b/src/replication/xsan_replication.c
@@ -1,0 +1,162 @@
+#include "xsan_replication.h"
+#include "xsan_memory.h"
+#include "xsan_log.h"
+#include "xsan_storage.h" // For xsan_volume_t definition
+#include "xsan_bdev.h"    // For xsan_bdev_dma_free
+#include "xsan_protocol.h" // For xsan_protocol_message_destroy (if per_replica_op_ctx is freed here)
+
+#include <string.h> // For memset
+
+xsan_replicated_io_ctx_t *xsan_replicated_io_ctx_create(
+    xsan_user_io_completion_cb_t original_user_cb,
+    void *original_user_cb_arg,
+    struct xsan_volume *vol,
+    const void *user_buffer,
+    uint64_t offset,
+    uint64_t length,
+    uint64_t transaction_id) {
+
+    if (!original_user_cb || !vol) {
+        XSAN_LOG_ERROR("Invalid params for replicated_io_ctx_create: cb or vol is NULL.");
+        return NULL;
+    }
+
+    xsan_replicated_io_ctx_t *rep_ctx = (xsan_replicated_io_ctx_t *)XSAN_MALLOC(sizeof(xsan_replicated_io_ctx_t));
+    if (!rep_ctx) {
+        XSAN_LOG_ERROR("Failed to allocate memory for xsan_replicated_io_ctx_t.");
+        return NULL;
+    }
+
+    memset(rep_ctx, 0, sizeof(xsan_replicated_io_ctx_t));
+
+    memcpy(&rep_ctx->volume_id, &vol->id, sizeof(xsan_volume_id_t));
+    rep_ctx->user_buffer = (void*)user_buffer; // Const cast, buffer is source for write
+    rep_ctx->logical_byte_offset = offset;
+    rep_ctx->length_bytes = length;
+    rep_ctx->original_user_cb = original_user_cb;
+    rep_ctx->original_user_cb_arg = original_user_cb_arg;
+    rep_ctx->transaction_id = transaction_id;
+
+    rep_ctx->total_replicas_targeted = vol->actual_replica_count;
+    if (rep_ctx->total_replicas_targeted == 0 || rep_ctx->total_replicas_targeted > XSAN_MAX_REPLICAS) {
+        XSAN_LOG_ERROR("Volume %s has invalid actual_replica_count %u for TID %lu. Cannot create rep_ctx.",
+            spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]), vol->actual_replica_count, transaction_id);
+        XSAN_FREE(rep_ctx);
+        return NULL;
+    }
+
+    rep_ctx->successful_writes = 0;
+    rep_ctx->failed_writes = 0;
+    rep_ctx->final_status = XSAN_OK; // Assume OK until a failure occurs
+    rep_ctx->local_io_req = NULL; // Will be set by volume_manager if local IO is submitted
+
+    return rep_ctx;
+}
+
+void xsan_replicated_io_ctx_free(xsan_replicated_io_ctx_t *rep_io_ctx) {
+    if (!rep_io_ctx) {
+        return;
+    }
+    // Note: rep_io_ctx->local_io_req (an xsan_io_request_t*) is typically freed by the
+    // xsan_io layer's completion callback (_xsan_io_spdk_completion_cb calls xsan_io_request_free).
+    // If there's an error path where local_io_req was created but not submitted or completed,
+    // it would need explicit freeing here or before this function is called.
+    // Current design in volume_manager seems to handle this: if submit_single_io_attempt fails,
+    // it calls the local_replica_write_complete_cb which sets local_io_req to NULL before
+    // _xsan_check_replicated_write_completion might free rep_io_ctx.
+    if (rep_io_ctx->local_io_req) {
+         XSAN_LOG_WARN("rep_io_ctx (TID %lu) freed while local_io_req was still set. This might be a leak if IO not completed/freed by xsan_io layer.", rep_io_ctx->transaction_id);
+         // xsan_io_request_free(rep_io_ctx->local_io_req); // Potentially add if known to be safe and necessary
+    }
+
+    XSAN_FREE(rep_io_ctx);
+}
+
+xsan_replica_read_coordinator_ctx_t *xsan_replica_read_coordinator_ctx_create(
+    struct xsan_volume *vol,
+    void *user_buffer,
+    uint64_t offset_bytes,
+    uint64_t length_bytes,
+    xsan_user_io_completion_cb_t original_user_cb,
+    void *original_user_cb_arg,
+    uint64_t transaction_id) {
+
+    if (!vol || !user_buffer || !original_user_cb) {
+        XSAN_LOG_ERROR("Invalid params for replica_read_coordinator_ctx_create: vol, buffer, or cb is NULL.");
+        return NULL;
+    }
+
+    xsan_replica_read_coordinator_ctx_t *coord_ctx =
+        (xsan_replica_read_coordinator_ctx_t *)XSAN_MALLOC(sizeof(xsan_replica_read_coordinator_ctx_t));
+    if (!coord_ctx) {
+        XSAN_LOG_ERROR("Failed to allocate memory for xsan_replica_read_coordinator_ctx_t.");
+        return NULL;
+    }
+
+    memset(coord_ctx, 0, sizeof(xsan_replica_read_coordinator_ctx_t));
+
+    coord_ctx->vol = vol; // Non-owning pointer
+    coord_ctx->user_buffer = user_buffer;
+    coord_ctx->logical_byte_offset = offset_bytes;
+    coord_ctx->length_bytes = length_bytes;
+    coord_ctx->original_user_cb = original_user_cb;
+    coord_ctx->original_user_cb_arg = original_user_cb_arg;
+    coord_ctx->transaction_id = transaction_id;
+
+    coord_ctx->current_replica_idx_to_try = 0;
+    coord_ctx->last_attempt_status = XSAN_OK; // Initial assumption
+    coord_ctx->internal_dma_buffer = NULL;
+    coord_ctx->internal_dma_buffer_size = 0;
+    coord_ctx->internal_dma_buffer_allocated = false;
+    coord_ctx->current_remote_op_ctx = NULL;
+
+    return coord_ctx;
+}
+
+void xsan_replica_read_coordinator_ctx_free(xsan_replica_read_coordinator_ctx_t *read_coord_ctx) {
+    if (!read_coord_ctx) {
+        return;
+    }
+
+    if (read_coord_ctx->internal_dma_buffer_allocated && read_coord_ctx->internal_dma_buffer) {
+        xsan_bdev_dma_free(read_coord_ctx->internal_dma_buffer);
+        read_coord_ctx->internal_dma_buffer = NULL;
+    }
+
+    if (read_coord_ctx->current_remote_op_ctx) {
+        // This context might contain a message that needs freeing
+        if (read_coord_ctx->current_remote_op_ctx->request_msg_to_send) {
+            xsan_protocol_message_destroy(read_coord_ctx->current_remote_op_ctx->request_msg_to_send);
+        }
+        XSAN_FREE(read_coord_ctx->current_remote_op_ctx);
+        read_coord_ctx->current_remote_op_ctx = NULL;
+    }
+    XSAN_FREE(read_coord_ctx);
+}
+
+// xsan_per_replica_op_ctx_t is simple enough to be malloc'd/freed directly
+// in volume_manager.c where it's used. If it becomes more complex,
+// dedicated create/free functions can be added here.
+// For example:
+/*
+xsan_per_replica_op_ctx_t *xsan_per_replica_op_ctx_create(void *parent_ctx, xsan_replica_location_t *loc_info) {
+    xsan_per_replica_op_ctx_t *pctx = XSAN_MALLOC(sizeof(xsan_per_replica_op_ctx_t));
+    if (pctx) {
+        memset(pctx, 0, sizeof(xsan_per_replica_op_ctx_t));
+        pctx->parent_rep_ctx = parent_ctx;
+        if (loc_info) {
+            memcpy(&pctx->replica_location_info, loc_info, sizeof(xsan_replica_location_t));
+        }
+    }
+    return pctx;
+}
+
+void xsan_per_replica_op_ctx_free(xsan_per_replica_op_ctx_t *pctx) {
+    if (pctx) {
+        if (pctx->request_msg_to_send) {
+            xsan_protocol_message_destroy(pctx->request_msg_to_send);
+        }
+        XSAN_FREE(pctx);
+    }
+}
+*/

--- a/src/storage/volume_manager.c
+++ b/src/storage/volume_manager.c
@@ -6,11 +6,13 @@
 #include "xsan_string_utils.h"
 #include "xsan_log.h"
 #include "xsan_error.h"
-#include "xsan_io.h"
-#include "xsan_replication.h"
+#include "xsan_io.h"       // For xsan_io_request_t and xsan_io_submit_request_to_bdev
+#include "xsan_replication.h" // For xsan_replicated_io_ctx_t, xsan_replica_read_coordinator_ctx_t, xsan_per_replica_op_ctx_t
 #include "xsan_node_comm.h"
 #include "xsan_protocol.h"
 #include "xsan_metadata_store.h"
+#include "xsan_bdev.h" // For xsan_bdev_get_buf_align, xsan_bdev_dma_malloc
+#include "xsan_cluster.h" // For xsan_get_local_node_info
 #include "json-c/json.h"
 
 #include "spdk/uuid.h"
@@ -21,6 +23,7 @@
 #include <errno.h>
 
 #define XSAN_VOLUME_META_PREFIX "v:"
+#define XSAN_DEFAULT_COMM_PORT 8080 // Placeholder, should come from config
 
 struct xsan_volume_manager {
     xsan_list_t *managed_volumes;
@@ -34,7 +37,19 @@ struct xsan_volume_manager {
     pthread_mutex_t pending_ios_lock;
 };
 
-static xsan_volume_manager_t *g_xsan_volume_manager_instance = NULL; // For callbacks to access vm
+static xsan_volume_manager_t *g_xsan_volume_manager_instance = NULL;
+
+// Context for the _xsan_physical_io_complete_cb callback
+typedef struct {
+    xsan_io_request_t *io_req;          // The xsan_io_request sent to xsan_io_submit_request_to_bdev
+    xsan_user_io_completion_cb_t actual_upper_cb; // e.g., _xsan_local_replica_write_complete_cb
+    void *actual_upper_cb_arg;        // e.g., rep_ctx
+    void* original_user_buffer;       // The very original buffer from the caller of read_async/write_async
+    bool is_read_op;
+    uint64_t length_bytes;
+    xsan_volume_id_t volume_id_for_log; // Store the volume ID for logging/debugging
+} xsan_vm_physical_io_ctx_t;
+
 
 // Forward declarations
 static xsan_error_t xsan_volume_manager_load_metadata(xsan_volume_manager_t *vm);
@@ -42,7 +57,7 @@ static xsan_error_t xsan_volume_manager_save_volume_meta(xsan_volume_manager_t *
 static xsan_error_t xsan_volume_manager_delete_volume_meta(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id);
 static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char **json_string_out);
 static xsan_error_t _xsan_json_string_to_volume(const char *json_string, xsan_volume_manager_t *vm, xsan_volume_t **vol_out);
-static xsan_error_t _xsan_volume_submit_single_io_attempt(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id, uint64_t logical_byte_offset, uint64_t length_bytes, void *user_buf, bool is_read_op, xsan_user_io_completion_cb_t user_cb, void *user_cb_arg);
+static xsan_error_t _xsan_volume_submit_single_io_attempt(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id, uint64_t logical_byte_offset, uint64_t length_bytes, void *original_user_buffer, bool is_read_op, xsan_user_io_completion_cb_t upper_completion_cb, void *upper_completion_cb_arg);
 
 static void _xsan_check_replicated_write_completion(xsan_replicated_io_ctx_t *rep_ctx);
 static void _xsan_local_replica_write_complete_cb(void *cb_arg, xsan_error_t status);
@@ -54,20 +69,21 @@ static void _xsan_replica_read_attempt_complete_cb(void *cb_arg, xsan_error_t st
 static void _xsan_remote_replica_read_req_send_complete_cb(int comm_status, void *cb_arg);
 static void _xsan_remote_replica_read_connect_then_send_cb(struct spdk_sock *sock, int status, void *cb_arg);
 static void _xsan_volume_update_overall_state(xsan_volume_manager_t *vm, xsan_volume_t *vol);
+static void _xsan_physical_io_complete_cb(void *cb_arg_from_io_layer, xsan_error_t status);
 
 
 static uint64_t _get_current_time_us() {
     return spdk_get_ticks() * SPDK_SEC_TO_USEC / spdk_get_ticks_hz();
 }
 
-static void _xsan_internal_volume_destroy_cb(void *volume_data) { /* ... as before ... */
+static void _xsan_internal_volume_destroy_cb(void *volume_data) {
     if (volume_data) { xsan_volume_t *v = (xsan_volume_t *)volume_data; XSAN_FREE(v); }
 }
-static uint32_t uint64_tid_hash_func(const void *key) { /* ... */ if(!key)return 0;uint64_t v=*(const uint64_t*)key;v=(~v)+(v<<21);v=v^(v>>24);v=(v+(v<<3))+(v<<8);v=v^(v>>14);v=(v+(v<<2))+(v<<4);v=v^(v>>28);v=v+(v<<31);return (uint32_t)v;}
-static int uint64_tid_key_compare_func(const void *k1,const void *k2){ /* ... */ if(k1==k2)return 0;if(!k1)return-1;if(!k2)return 1;uint64_t v1=*(const uint64_t*)k1;uint64_t v2=*(const uint64_t*)k2;if(v1<v2)return-1;if(v1>v2)return 1;return 0;}
+static uint32_t uint64_tid_hash_func(const void *key) { if(!key)return 0;uint64_t v=*(const uint64_t*)key;v=(~v)+(v<<21);v=v^(v>>24);v=(v+(v<<3))+(v<<8);v=v^(v>>14);v=(v+(v<<2))+(v<<4);v=v^(v>>28);v=v+(v<<31);return (uint32_t)v;}
+static int uint64_tid_key_compare_func(const void *k1,const void *k2){ if(k1==k2)return 0;if(!k1)return-1;if(!k2)return 1;uint64_t v1=*(const uint64_t*)k1;uint64_t v2=*(const uint64_t*)k2;if(v1<v2)return-1;if(v1>v2)return 1;return 0;}
 
 
-xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *dm, xsan_volume_manager_t **vm_out){ /* ... as before ... */
+xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *dm, xsan_volume_manager_t **vm_out){
     const char *default_db_path_suffix = "xsan_meta_db/volume_manager";
     char actual_db_path[XSAN_MAX_PATH_LEN];
     snprintf(actual_db_path, sizeof(actual_db_path), "./%s", default_db_path_suffix);
@@ -79,29 +95,30 @@ xsan_error_t xsan_volume_manager_init(xsan_disk_manager_t *dm, xsan_volume_manag
     memset(vm,0,sizeof(*vm)); xsan_strcpy_safe(vm->metadata_db_path,actual_db_path,XSAN_MAX_PATH_LEN);
     vm->managed_volumes=xsan_list_create(_xsan_internal_volume_destroy_cb);
     if(!vm->managed_volumes || pthread_mutex_init(&vm->lock,NULL)!=0 || pthread_mutex_init(&vm->pending_ios_lock,NULL)!=0){ XSAN_FREE(vm); return XSAN_ERROR_SYSTEM;}
-    vm->pending_replicated_ios=xsan_hashtable_create(256,uint64_tid_hash_func,uint64_tid_key_compare_func,NULL,NULL);
-    if(!vm->pending_replicated_ios){ XSAN_FREE(vm); return XSAN_ERROR_OUT_OF_MEMORY;}
-    vm->pending_replica_reads = xsan_hashtable_create(256, uint64_tid_hash_func, uint64_tid_key_compare_func, NULL, NULL);
-    if(!vm->pending_replica_reads){ xsan_hashtable_destroy(vm->pending_replicated_ios); XSAN_FREE(vm); return XSAN_ERROR_OUT_OF_MEMORY;}
+    vm->pending_replicated_ios=xsan_hashtable_create(256,uint64_tid_hash_func,uint64_tid_key_compare_func,NULL, (void(*)(void*))xsan_replicated_io_ctx_free); // Added free func
+    if(!vm->pending_replicated_ios){ pthread_mutex_destroy(&vm->lock); pthread_mutex_destroy(&vm->pending_ios_lock); xsan_list_destroy(vm->managed_volumes); XSAN_FREE(vm); return XSAN_ERROR_OUT_OF_MEMORY;}
+    vm->pending_replica_reads = xsan_hashtable_create(256, uint64_tid_hash_func, uint64_tid_key_compare_func, NULL, (void(*)(void*))xsan_replica_read_coordinator_ctx_free); // Added free func
+    if(!vm->pending_replica_reads){ xsan_hashtable_destroy(vm->pending_replicated_ios); pthread_mutex_destroy(&vm->lock); pthread_mutex_destroy(&vm->pending_ios_lock); xsan_list_destroy(vm->managed_volumes); XSAN_FREE(vm); return XSAN_ERROR_OUT_OF_MEMORY;}
     vm->disk_manager=dm; vm->md_store=xsan_metadata_store_open(vm->metadata_db_path,true);
-    if(!vm->md_store){ xsan_hashtable_destroy(vm->pending_replica_reads); xsan_hashtable_destroy(vm->pending_replicated_ios); XSAN_FREE(vm); return XSAN_ERROR_STORAGE_GENERIC;}
+    if(!vm->md_store){ xsan_hashtable_destroy(vm->pending_replica_reads); xsan_hashtable_destroy(vm->pending_replicated_ios); pthread_mutex_destroy(&vm->lock); pthread_mutex_destroy(&vm->pending_ios_lock); xsan_list_destroy(vm->managed_volumes); XSAN_FREE(vm); return XSAN_ERROR_STORAGE_GENERIC;}
     vm->initialized=true; g_xsan_volume_manager_instance=vm; if(vm_out)*vm_out=vm;
     xsan_volume_manager_load_metadata(vm); XSAN_LOG_INFO("Volume Manager initialized."); return XSAN_OK;
 }
-void xsan_volume_manager_fini(xsan_volume_manager_t **vm_ptr){ /* ... as before ... */
+
+void xsan_volume_manager_fini(xsan_volume_manager_t **vm_ptr){
     xsan_volume_manager_t *vm = (vm_ptr && *vm_ptr) ? *vm_ptr : g_xsan_volume_manager_instance;
-    if (!vm || !vm->initialized) { if(vm_ptr) *vm_ptr = NULL; g_xsan_volume_manager_instance = NULL; return; }
+    if (!vm || !vm->initialized) { if(vm_ptr) *vm_ptr = NULL; if(vm==g_xsan_volume_manager_instance)g_xsan_volume_manager_instance=NULL; return; }
     XSAN_LOG_INFO("Finalizing Volume Manager...");
     pthread_mutex_lock(&vm->pending_ios_lock);
-    if(vm->pending_replicated_ios){ xsan_hashtable_iter_t it_w; xsan_hashtable_iter_init(vm->pending_replicated_ios, &it_w); void *k_w,*v_w; while(xsan_hashtable_iter_next(&it_w,&k_w,&v_w)){if(v_w)xsan_replicated_io_ctx_free(v_w);} xsan_hashtable_destroy(vm->pending_replicated_ios);vm->pending_replicated_ios=NULL;}
-    if(vm->pending_replica_reads){ xsan_hashtable_iter_t it_r; xsan_hashtable_iter_init(vm->pending_replica_reads, &it_r); void *k_r,*v_r; while(xsan_hashtable_iter_next(&it_r,&k_r,&v_r)){if(v_r)xsan_replica_read_coordinator_ctx_free(v_r);} xsan_hashtable_destroy(vm->pending_replica_reads);vm->pending_replica_reads=NULL;}
+    if(vm->pending_replicated_ios){ xsan_hashtable_destroy(vm->pending_replicated_ios);vm->pending_replicated_ios=NULL;} // Free func in create handles elements
+    if(vm->pending_replica_reads){ xsan_hashtable_destroy(vm->pending_replica_reads);vm->pending_replica_reads=NULL;} // Free func in create handles elements
     pthread_mutex_unlock(&vm->pending_ios_lock); pthread_mutex_destroy(&vm->pending_ios_lock);
-    pthread_mutex_lock(&vm->lock); xsan_list_destroy(vm->managed_volumes); if(vm->md_store)xsan_metadata_store_close(vm->md_store); pthread_mutex_unlock(&vm->lock); pthread_mutex_destroy(&vm->lock);
+    pthread_mutex_lock(&vm->lock); xsan_list_destroy(vm->managed_volumes); vm->managed_volumes = NULL; if(vm->md_store)xsan_metadata_store_close(vm->md_store); vm->md_store = NULL; pthread_mutex_unlock(&vm->lock); pthread_mutex_destroy(&vm->lock);
     XSAN_FREE(vm); if(vm_ptr)*vm_ptr=NULL; if(vm==g_xsan_volume_manager_instance)g_xsan_volume_manager_instance=NULL;
     XSAN_LOG_INFO("Volume Manager finalized.");
 }
 
-static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char **json_s_out){ /* ... as before, includes replica_nodes with state and contact time ... */
+static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char **json_s_out){
     if (!vol || !json_s_out) return XSAN_ERROR_INVALID_PARAM;
     json_object *jobj = json_object_new_object(); char uuid_buf[SPDK_UUID_STRING_LEN];
     spdk_uuid_fmt_lower(uuid_buf, sizeof(uuid_buf), (const struct spdk_uuid *)&vol->id.data[0]); json_object_object_add(jobj, "id", json_object_new_string(uuid_buf));
@@ -109,7 +126,7 @@ static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char *
     json_object_object_add(jobj, "size_bytes", json_object_new_int64(vol->size_bytes));
     json_object_object_add(jobj, "block_size_bytes", json_object_new_int(vol->block_size_bytes));
     json_object_object_add(jobj, "num_blocks", json_object_new_int64(vol->num_blocks));
-    json_object_object_add(jobj, "state", json_object_new_int(vol->state)); // Overall volume state
+    json_object_object_add(jobj, "state", json_object_new_int(vol->state));
     spdk_uuid_fmt_lower(uuid_buf, sizeof(uuid_buf), (const struct spdk_uuid *)&vol->source_group_id.data[0]); json_object_object_add(jobj, "source_group_id", json_object_new_string(uuid_buf));
     json_object_object_add(jobj, "thin_provisioned", json_object_new_boolean(vol->thin_provisioned));
     json_object_object_add(jobj, "allocated_bytes", json_object_new_int64(vol->allocated_bytes));
@@ -121,7 +138,7 @@ static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char *
         spdk_uuid_fmt_lower(uuid_buf, sizeof(uuid_buf), (const struct spdk_uuid *)&vol->replica_nodes[i].node_id.data[0]); json_object_object_add(jreplica, "node_id", json_object_new_string(uuid_buf));
         json_object_object_add(jreplica, "node_ip_addr", json_object_new_string(vol->replica_nodes[i].node_ip_addr));
         json_object_object_add(jreplica, "node_comm_port", json_object_new_int(vol->replica_nodes[i].node_comm_port));
-        json_object_object_add(jreplica, "state", json_object_new_int(vol->replica_nodes[i].state)); // Persist replica state
+        json_object_object_add(jreplica, "state", json_object_new_int(vol->replica_nodes[i].state));
         json_object_object_add(jreplica, "last_successful_contact_time_us", json_object_new_int64(vol->replica_nodes[i].last_successful_contact_time_us));
         json_object_array_add(jarray_replicas, jreplica);
     }
@@ -130,7 +147,8 @@ static xsan_error_t _xsan_volume_to_json_string(const xsan_volume_t *vol, char *
     *json_s_out = xsan_strdup(tmp_str); json_object_put(jobj);
     return (*json_s_out) ? XSAN_OK : XSAN_ERROR_OUT_OF_MEMORY;
 }
-static xsan_error_t _xsan_json_string_to_volume(const char *js, xsan_volume_manager_t *vm, xsan_volume_t **v_out){ /* ... as before, includes replica_nodes with state and contact time ... */
+
+static xsan_error_t _xsan_json_string_to_volume(const char *js, xsan_volume_manager_t *vm, xsan_volume_t **v_out){
     (void)vm; if (!js || !v_out) return XSAN_ERROR_INVALID_PARAM;
     struct json_object *jobj = json_tokener_parse(js); if (!jobj || is_error(jobj)) { if(jobj&&!is_error(jobj))json_object_put(jobj);return XSAN_ERROR_CONFIG_PARSE; }
     xsan_volume_t *vol = (xsan_volume_t *)XSAN_MALLOC(sizeof(*vol)); if (!vol) { json_object_put(jobj); return XSAN_ERROR_OUT_OF_MEMORY; }
@@ -140,7 +158,7 @@ static xsan_error_t _xsan_json_string_to_volume(const char *js, xsan_volume_mana
     if (json_object_object_get_ex(jobj, "size_bytes", &val)) vol->size_bytes = (uint64_t)json_object_get_int64(val);
     if (json_object_object_get_ex(jobj, "block_size_bytes", &val)) vol->block_size_bytes = (uint32_t)json_object_get_int(val);
     if (json_object_object_get_ex(jobj, "num_blocks", &val)) vol->num_blocks = (uint64_t)json_object_get_int64(val);
-    if (json_object_object_get_ex(jobj, "state", &val)) vol->state = (xsan_storage_state_t)json_object_get_int(val); else vol->state = XSAN_STORAGE_STATE_OFFLINE; // Default loaded state
+    if (json_object_object_get_ex(jobj, "state", &val)) vol->state = (xsan_storage_state_t)json_object_get_int(val); else vol->state = XSAN_STORAGE_STATE_OFFLINE;
     if (json_object_object_get_ex(jobj, "source_group_id", &val)) spdk_uuid_parse((struct spdk_uuid*)&vol->source_group_id.data[0], json_object_get_string(val));
     if (json_object_object_get_ex(jobj, "thin_provisioned", &val)) vol->thin_provisioned = json_object_get_boolean(val);
     if (json_object_object_get_ex(jobj, "allocated_bytes", &val)) vol->allocated_bytes = (uint64_t)json_object_get_int64(val);
@@ -157,7 +175,7 @@ static xsan_error_t _xsan_json_string_to_volume(const char *js, xsan_volume_mana
                 if (json_object_object_get_ex(j_repl_node, "node_id", &val)) spdk_uuid_parse((struct spdk_uuid*)&vol->replica_nodes[i].node_id.data[0], json_object_get_string(val));
                 if (json_object_object_get_ex(j_repl_node, "node_ip_addr", &val)) xsan_strcpy_safe(vol->replica_nodes[i].node_ip_addr, json_object_get_string(val), INET6_ADDRSTRLEN);
                 if (json_object_object_get_ex(j_repl_node, "node_comm_port", &val)) vol->replica_nodes[i].node_comm_port = (uint16_t)json_object_get_int(val);
-                if (json_object_object_get_ex(j_repl_node, "state", &val)) vol->replica_nodes[i].state = (xsan_storage_state_t)json_object_get_int(val); else vol->replica_nodes[i].state = XSAN_STORAGE_STATE_UNKNOWN; // Default if missing
+                if (json_object_object_get_ex(j_repl_node, "state", &val)) vol->replica_nodes[i].state = (xsan_storage_state_t)json_object_get_int(val); else vol->replica_nodes[i].state = XSAN_STORAGE_STATE_UNKNOWN;
                 if (json_object_object_get_ex(j_repl_node, "last_successful_contact_time_us", &val)) vol->replica_nodes[i].last_successful_contact_time_us = (uint64_t)json_object_get_int64(val);
             }
         }
@@ -167,12 +185,8 @@ static xsan_error_t _xsan_json_string_to_volume(const char *js, xsan_volume_mana
 
 static void _xsan_volume_update_overall_state(xsan_volume_manager_t *vm, xsan_volume_t *vol) {
     if (!vm || !vol) return;
-    // This function should be called with vm->lock HELD or from a context that ensures serial access to 'vol'.
-    // However, to save metadata, it will call save_volume_meta which also takes vm->lock.
-    // This can lead to recursive locking if not careful.
-    // For now, assume this function is called when vm->lock is NOT held, or make save_volume_meta take a flag to not lock.
-    // Alternative: this function only calculates state, and caller saves if changed.
 
+    pthread_mutex_lock(&vm->lock);
     xsan_storage_state_t old_vol_state = vol->state;
     uint32_t online_replicas = 0;
     for (uint32_t i = 0; i < vol->actual_replica_count; ++i) {
@@ -182,171 +196,958 @@ static void _xsan_volume_update_overall_state(xsan_volume_manager_t *vm, xsan_vo
     }
 
     uint32_t required_online_for_ok = vol->FTT + 1;
-    // Cap required_online_for_ok at actual_replica_count if actual is less (e.g. during initial setup or degraded state)
     if (required_online_for_ok > vol->actual_replica_count && vol->actual_replica_count > 0) {
         required_online_for_ok = vol->actual_replica_count;
     }
 
-
     if (online_replicas >= required_online_for_ok) {
         vol->state = XSAN_STORAGE_STATE_ONLINE;
-    } else if (online_replicas > 0) { // Still has some online replicas, but not full redundancy
+    } else if (online_replicas > 0) {
         vol->state = XSAN_STORAGE_STATE_DEGRADED;
-    } else { // No online replicas
-        vol->state = XSAN_STORAGE_STATE_OFFLINE; // Or FAILED
+    } else {
+        vol->state = XSAN_STORAGE_STATE_OFFLINE;
     }
 
-    if (vol->state != old_vol_state) {
+    bool state_changed = (vol->state != old_vol_state);
+    pthread_mutex_unlock(&vm->lock);
+
+    if (state_changed) {
         XSAN_LOG_INFO("Volume '%s' (ID: %s) overall state changed from %d to %d (Online Replicas: %u/%u, FTT: %u)",
                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]),
                       old_vol_state, vol->state, online_replicas, vol->actual_replica_count, vol->FTT);
-        xsan_volume_manager_save_volume_meta(vm, vol); // Persist the change
+        xsan_volume_manager_save_volume_meta(vm, vol);
     }
 }
 
-static xsan_error_t xsan_volume_manager_save_volume_meta(xsan_volume_manager_t *vm, xsan_volume_t *vol) { /* ... */ return XSAN_OK;}
-static xsan_error_t xsan_volume_manager_delete_volume_meta(xsan_volume_manager_t *vm, xsan_volume_id_t v_id) { /* ... */ return XSAN_OK;}
-xsan_error_t xsan_volume_manager_load_metadata(xsan_volume_manager_t *vm) { /* ... */ return XSAN_OK;}
-xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm, const char *name, uint64_t size_bytes, xsan_group_id_t group_id, uint32_t logical_block_size_bytes, bool thin, uint32_t ftt, xsan_volume_id_t *vol_id_out ) { /* ... as before, but init replica_nodes[i].state and last_successful_contact_time_us ... */
-    // In xsan_volume_create, after populating replica_nodes[0] (local):
-    // new_volume->replica_nodes[0].state = XSAN_STORAGE_STATE_ONLINE;
-    // new_volume->replica_nodes[0].last_successful_contact_time_us = _get_current_time_us();
-    // For remote replicas (placeholder):
-    // new_volume->replica_nodes[i].state = XSAN_STORAGE_STATE_INITIALIZING; // Or UNKNOWN
-    // new_volume->replica_nodes[i].last_successful_contact_time_us = 0;
-    // Then call _xsan_volume_update_overall_state(vm, new_volume); before saving.
+static xsan_error_t xsan_volume_manager_save_volume_meta(xsan_volume_manager_t *vm, xsan_volume_t *vol) {
+    if (!vm || !vm->md_store || !vol) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    char *json_string = NULL;
+    xsan_error_t err = _xsan_volume_to_json_string(vol, &json_string);
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("Failed to serialize volume '%s' (ID: %s) to JSON: %s",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]), xsan_error_string(err));
+        return err;
+    }
+    char key_buf[XSAN_MAX_NAME_LEN + SPDK_UUID_STRING_LEN];
+    snprintf(key_buf, sizeof(key_buf), "%s%s", XSAN_VOLUME_META_PREFIX, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]));
+    err = xsan_metadata_store_put(vm->md_store, key_buf, strlen(key_buf), json_string, strlen(json_string));
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("Failed to save volume '%s' (ID: %s) metadata to RocksDB: %s",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]), xsan_error_string(err));
+    } else {
+        XSAN_LOG_DEBUG("Successfully saved volume '%s' (ID: %s) metadata.",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]));
+    }
+    XSAN_FREE(json_string);
+    return err;
+}
+
+static xsan_error_t xsan_volume_manager_delete_volume_meta(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id) {
+    if (!vm || !vm->md_store || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    char key_buf[XSAN_MAX_NAME_LEN + SPDK_UUID_STRING_LEN];
+    snprintf(key_buf, sizeof(key_buf), "%s%s", XSAN_VOLUME_META_PREFIX, spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+    xsan_error_t err = xsan_metadata_store_delete(vm->md_store, key_buf, strlen(key_buf));
+    if (err != XSAN_OK && err != XSAN_ERROR_NOT_FOUND) {
+        XSAN_LOG_ERROR("Failed to delete volume (ID: %s) metadata from RocksDB: %s",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), xsan_error_string(err));
+    } else {
+        XSAN_LOG_DEBUG("Successfully deleted/confirmed deletion of volume (ID: %s) metadata.",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        if (err == XSAN_ERROR_NOT_FOUND) err = XSAN_OK;
+    }
+    return err;
+}
+
+xsan_error_t xsan_volume_manager_load_metadata(xsan_volume_manager_t *vm) {
+    if (!vm || !vm->initialized || !vm->md_store) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    XSAN_LOG_INFO("Loading volume metadata from RocksDB store: %s", vm->metadata_db_path);
+    pthread_mutex_lock(&vm->lock);
+    xsan_metadata_iterator_t *iter = xsan_metadata_iterator_create(vm->md_store);
+    if (!iter) {
+        XSAN_LOG_ERROR("Failed to create metadata iterator for volume loading.");
+        pthread_mutex_unlock(&vm->lock);
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    xsan_metadata_iterator_seek(iter, XSAN_VOLUME_META_PREFIX, strlen(XSAN_VOLUME_META_PREFIX));
+    while (xsan_metadata_iterator_is_valid(iter)) {
+        size_t key_len;
+        const char *key = xsan_metadata_iterator_key(iter, &key_len);
+        if (!key || strncmp(key, XSAN_VOLUME_META_PREFIX, strlen(XSAN_VOLUME_META_PREFIX)) != 0) {
+            break;
+        }
+        size_t value_len;
+        const char *value_str = xsan_metadata_iterator_value(iter, &value_len);
+        if (value_str) {
+            xsan_volume_t *vol = NULL;
+            xsan_error_t deser_err = _xsan_json_string_to_volume(value_str, vm, &vol);
+            if (deser_err == XSAN_OK && vol) {
+                if (xsan_list_append(vm->managed_volumes, vol) != NULL) {
+                    XSAN_LOG_DEBUG("Loaded volume '%s' (ID: %s) from metadata.",
+                                   vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]));
+                     _xsan_volume_update_overall_state(vm, vol);
+                } else {
+                    XSAN_LOG_ERROR("Failed to append loaded volume '%s' to list.", vol->name);
+                    _xsan_internal_volume_destroy_cb(vol);
+                }
+            } else {
+                XSAN_LOG_ERROR("Failed to deserialize volume from metadata key '%.*s': %s",
+                               (int)key_len, key, xsan_error_string(deser_err));
+            }
+        }
+        xsan_metadata_iterator_next(iter);
+    }
+    xsan_metadata_iterator_destroy(iter);
+    pthread_mutex_unlock(&vm->lock);
+    XSAN_LOG_INFO("Volume metadata loading complete.");
     return XSAN_OK;
 }
-xsan_error_t xsan_volume_delete(xsan_volume_manager_t *vm, xsan_volume_id_t vid){ /* ... */ return XSAN_OK;}
-xsan_volume_t *xsan_volume_get_by_id(xsan_volume_manager_t *vm, xsan_volume_id_t vid){ /* ... */ return NULL;}
-xsan_volume_t *xsan_volume_get_by_name(xsan_volume_manager_t *vm, const char *n){ /* ... */ return NULL;}
-xsan_error_t xsan_volume_list_all(xsan_volume_manager_t *vm, xsan_volume_t ***v_arr_out, int *c_out){ /* ... */ return XSAN_OK;}
-void xsan_volume_manager_free_volume_pointer_list(xsan_volume_t **v_ptr_arr){ /* ... */ if(v_ptr_arr)XSAN_FREE(v_ptr_arr);}
-xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm, xsan_volume_id_t vid, uint64_t lba_idx, xsan_disk_id_t *d_id_out, uint64_t *p_lba_out, uint32_t *p_bs_out){ /* ... */ return XSAN_OK;}
 
-static void _xsan_check_replicated_write_completion(xsan_replicated_io_ctx_t *rep_ctx) { /* ... as before ... */
-    if(!rep_ctx)return; uint32_t done_c = __sync_add_and_fetch(&rep_ctx->successful_writes,0) + __sync_add_and_fetch(&rep_ctx->failed_writes,0);
-    if(done_c >= rep_ctx->total_replicas_targeted){
-        xsan_volume_t *vol = xsan_volume_get_by_id(g_xsan_volume_manager_instance, rep_ctx->volume_id); // Get volume to update its state
-        if(rep_ctx->successful_writes >= rep_ctx->total_replicas_targeted) rep_ctx->final_status=XSAN_OK;
-        else if(rep_ctx->final_status==XSAN_OK)rep_ctx->final_status=XSAN_ERROR_REPLICATION_GENERIC;
-        if(vol) _xsan_volume_update_overall_state(g_xsan_volume_manager_instance, vol); // Update overall vol state
-        if(rep_ctx->original_user_cb)rep_ctx->original_user_cb(rep_ctx->original_user_cb_arg,rep_ctx->final_status);
-        pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock); xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replicated_ios,&rep_ctx->transaction_id); pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock);
-        xsan_replicated_io_ctx_free(rep_ctx);
+xsan_error_t xsan_volume_create(xsan_volume_manager_t *vm, const char *name, uint64_t size_bytes, xsan_group_id_t group_id, uint32_t logical_block_size_bytes, bool thin, uint32_t ftt, xsan_volume_id_t *vol_id_out ) {
+    if (!vm || !vm->initialized || !name || size_bytes == 0 || spdk_uuid_is_null((struct spdk_uuid*)&group_id.data[0]) ||
+        (logical_block_size_bytes != 512 && logical_block_size_bytes != 4096) || ftt >= XSAN_MAX_REPLICAS ) {
+        return XSAN_ERROR_INVALID_PARAM;
     }
+    pthread_mutex_lock(&vm->lock);
+    xsan_error_t err = XSAN_OK;
+    xsan_list_node_t *node_iter;
+    XSAN_LIST_FOREACH(vm->managed_volumes, node_iter) {
+        xsan_volume_t *v = (xsan_volume_t*)xsan_list_node_get_value(node_iter);
+        if(strncmp(v->name, name, XSAN_MAX_NAME_LEN) == 0) {
+            err = XSAN_ERROR_ALREADY_EXISTS;
+            goto cleanup_unlock;
+        }
+    }
+    xsan_disk_group_t *dg = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, group_id);
+    if (!dg) {
+        err = XSAN_ERROR_NOT_FOUND;
+        goto cleanup_unlock;
+    }
+    if (dg->state != XSAN_STORAGE_STATE_ONLINE) {
+        err = XSAN_ERROR_RESOURCE_UNAVAILABLE;
+        goto cleanup_unlock;
+    }
+    if (!thin && size_bytes > dg->usable_capacity_bytes) {
+        err = XSAN_ERROR_INSUFFICIENT_SPACE;
+        goto cleanup_unlock;
+    }
+    xsan_volume_t *new_volume = (xsan_volume_t *)XSAN_MALLOC(sizeof(xsan_volume_t));
+    if (!new_volume) {
+        err = XSAN_ERROR_OUT_OF_MEMORY;
+        goto cleanup_unlock;
+    }
+    memset(new_volume, 0, sizeof(xsan_volume_t));
+    spdk_uuid_generate((struct spdk_uuid *)&new_volume->id.data[0]);
+    xsan_strcpy_safe(new_volume->name, name, XSAN_MAX_NAME_LEN);
+    new_volume->size_bytes = size_bytes;
+    new_volume->block_size_bytes = logical_block_size_bytes;
+    new_volume->num_blocks = size_bytes / logical_block_size_bytes;
+    if (size_bytes % logical_block_size_bytes != 0) {
+        new_volume->num_blocks++;
+        new_volume->size_bytes = new_volume->num_blocks * logical_block_size_bytes;
+        XSAN_LOG_WARN("Volume '%s' size adjusted to %lu bytes to be block aligned (block size %u).",
+                      name, new_volume->size_bytes, logical_block_size_bytes);
+    }
+    memcpy(&new_volume->source_group_id, &group_id, sizeof(xsan_group_id_t));
+    new_volume->thin_provisioned = thin;
+    new_volume->allocated_bytes = thin ? 0 : new_volume->size_bytes;
+    new_volume->FTT = ftt;
+    new_volume->actual_replica_count = ftt + 1;
+    if (new_volume->actual_replica_count > XSAN_MAX_REPLICAS) {
+        new_volume->actual_replica_count = XSAN_MAX_REPLICAS;
+        XSAN_LOG_WARN("Requested replica count for vol '%s' (%u) exceeds max (%d), capped.", name, ftt+1, XSAN_MAX_REPLICAS);
+    }
+    xsan_node_id_t local_node_id;
+    char local_ip[INET6_ADDRSTRLEN];
+    uint16_t local_port;
+    xsan_get_local_node_info(&local_node_id, local_ip, sizeof(local_ip), &local_port);
+    memcpy(&new_volume->replica_nodes[0].node_id, &local_node_id, sizeof(xsan_node_id_t));
+    xsan_strcpy_safe(new_volume->replica_nodes[0].node_ip_addr, local_ip, INET6_ADDRSTRLEN);
+    new_volume->replica_nodes[0].node_comm_port = local_port;
+    new_volume->replica_nodes[0].state = XSAN_STORAGE_STATE_ONLINE;
+    new_volume->replica_nodes[0].last_successful_contact_time_us = _get_current_time_us();
+    for (uint32_t i = 1; i < new_volume->actual_replica_count; ++i) {
+        memset(&new_volume->replica_nodes[i].node_id, 0, sizeof(xsan_node_id_t));
+        strcpy(new_volume->replica_nodes[i].node_ip_addr, "0.0.0.0");
+        new_volume->replica_nodes[i].node_comm_port = 0;
+        new_volume->replica_nodes[i].state = XSAN_STORAGE_STATE_INITIALIZING;
+        new_volume->replica_nodes[i].last_successful_contact_time_us = 0;
+    }
+    new_volume->state = XSAN_STORAGE_STATE_INITIALIZING;
+    if (xsan_list_append(vm->managed_volumes, new_volume) == NULL) {
+        err = XSAN_ERROR_OUT_OF_MEMORY;
+        XSAN_FREE(new_volume);
+        goto cleanup_unlock;
+    }
+    _xsan_volume_update_overall_state(vm, new_volume);
+    if (new_volume->state == XSAN_STORAGE_STATE_INITIALIZING && err == XSAN_OK) {
+         err = xsan_volume_manager_save_volume_meta(vm, new_volume);
+    }
+    if (err != XSAN_OK) {
+        XSAN_LOG_ERROR("Failed to save metadata for new volume '%s'. It remains in memory but not persisted.", name);
+    }
+    if (vol_id_out) {
+        memcpy(vol_id_out, &new_volume->id, sizeof(xsan_volume_id_t));
+    }
+    if(err == XSAN_OK) {
+        XSAN_LOG_INFO("Volume '%s' (ID: %s) created successfully. Size: %lu bytes, FTT: %u.",
+                  new_volume->name, spdk_uuid_get_string((struct spdk_uuid*)&new_volume->id.data[0]),
+                  new_volume->size_bytes, new_volume->FTT);
+    }
+cleanup_unlock:
+    pthread_mutex_unlock(&vm->lock);
+    return err;
 }
+
+xsan_error_t xsan_volume_delete(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id){
+    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    pthread_mutex_lock(&vm->lock);
+    xsan_error_t err = XSAN_ERROR_NOT_FOUND;
+    xsan_list_node_t *node = xsan_list_get_head(vm->managed_volumes);
+    xsan_volume_t *vol_to_delete = NULL;
+    while (node != NULL) {
+        xsan_volume_t *current_vol = (xsan_volume_t *)xsan_list_node_get_value(node);
+        if (spdk_uuid_compare((struct spdk_uuid*)&current_vol->id.data[0], (struct spdk_uuid*)&volume_id.data[0]) == 0) {
+            vol_to_delete = current_vol;
+            break;
+        }
+        node = xsan_list_node_next(node);
+    }
+    if (vol_to_delete) {
+        xsan_list_remove_node(vm->managed_volumes, node);
+        vol_to_delete = NULL;
+        err = xsan_volume_manager_delete_volume_meta(vm, volume_id);
+        if (err != XSAN_OK) {
+            XSAN_LOG_ERROR("Failed to delete metadata for volume ID %s. In-memory entry removed.",
+                           spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        } else {
+            XSAN_LOG_INFO("Volume (ID: %s) deleted successfully.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        }
+        err = XSAN_OK;
+    }
+    pthread_mutex_unlock(&vm->lock);
+    return err;
+}
+
+xsan_volume_t *xsan_volume_get_by_id(xsan_volume_manager_t *vm, xsan_volume_id_t volume_id){
+    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) {
+        return NULL;
+    }
+    pthread_mutex_lock(&vm->lock);
+    xsan_list_node_t *node;
+    xsan_volume_t *found_volume = NULL;
+    XSAN_LIST_FOREACH(vm->managed_volumes, node) {
+        xsan_volume_t *vol = (xsan_volume_t *)xsan_list_node_get_value(node);
+        if (spdk_uuid_compare((struct spdk_uuid*)&vol->id.data[0], (struct spdk_uuid*)&volume_id.data[0]) == 0) {
+            found_volume = vol;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&vm->lock);
+    return found_volume;
+}
+
+xsan_volume_t *xsan_volume_get_by_name(xsan_volume_manager_t *vm, const char *name){
+    if (!vm || !vm->initialized || !name) {
+        return NULL;
+    }
+    pthread_mutex_lock(&vm->lock);
+    xsan_list_node_t *node;
+    xsan_volume_t *found_volume = NULL;
+    XSAN_LIST_FOREACH(vm->managed_volumes, node) {
+        xsan_volume_t *vol = (xsan_volume_t *)xsan_list_node_get_value(node);
+        if (strncmp(vol->name, name, XSAN_MAX_NAME_LEN) == 0) {
+            found_volume = vol;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&vm->lock);
+    return found_volume;
+}
+
+xsan_error_t xsan_volume_list_all(xsan_volume_manager_t *vm, xsan_volume_t ***volumes_array_out, int *count_out){
+    if (!vm || !vm->initialized || !volumes_array_out || !count_out) {
+        if (count_out) *count_out = 0;
+        if (volumes_array_out) *volumes_array_out = NULL;
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    pthread_mutex_lock(&vm->lock);
+    size_t num_volumes = xsan_list_size(vm->managed_volumes);
+    if (num_volumes == 0) {
+        *volumes_array_out = NULL;
+        *count_out = 0;
+        pthread_mutex_unlock(&vm->lock);
+        return XSAN_OK;
+    }
+    *volumes_array_out = (xsan_volume_t **)XSAN_MALLOC(sizeof(xsan_volume_t*) * num_volumes);
+    if (!*volumes_array_out) {
+        *count_out = 0;
+        pthread_mutex_unlock(&vm->lock);
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+    int i = 0;
+    xsan_list_node_t *node;
+    XSAN_LIST_FOREACH(vm->managed_volumes, node) {
+        if (i < (int)num_volumes) {
+            (*volumes_array_out)[i++] = (xsan_volume_t *)xsan_list_node_get_value(node);
+        } else {
+            break;
+        }
+    }
+    *count_out = i;
+    pthread_mutex_unlock(&vm->lock);
+    return XSAN_OK;
+}
+
+void xsan_volume_manager_free_volume_pointer_list(xsan_volume_t **v_ptr_arr){ if(v_ptr_arr)XSAN_FREE(v_ptr_arr);}
+
+xsan_error_t xsan_volume_map_lba_to_physical(xsan_volume_manager_t *vm,
+                                             xsan_volume_id_t volume_id,
+                                             uint64_t logical_block_idx,
+                                             xsan_disk_id_t *out_disk_id,
+                                             uint64_t *out_physical_block_idx,
+                                             uint32_t *out_physical_block_size) {
+    if (!vm || !vm->initialized || spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0]) ||
+        !out_disk_id || !out_physical_block_idx || !out_physical_block_size) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+    xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id);
+    if (!vol) {
+        return XSAN_ERROR_NOT_FOUND;
+    }
+    if (logical_block_idx >= vol->num_blocks) {
+        return XSAN_ERROR_OUT_OF_BOUNDS;
+    }
+    xsan_disk_group_t *dg = xsan_disk_manager_find_disk_group_by_id(vm->disk_manager, vol->source_group_id);
+    if (!dg) {
+        XSAN_LOG_ERROR("Volume %s (ID: %s) source disk group (ID: %s) not found.",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]),
+                       spdk_uuid_get_string((struct spdk_uuid*)&vol->source_group_id.data[0]));
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    if (dg->disk_count == 0 || dg->state != XSAN_STORAGE_STATE_ONLINE) {
+        XSAN_LOG_ERROR("Volume %s (ID: %s) source disk group '%s' has no disks or is not online (State: %d).",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&vol->id.data[0]), dg->name, dg->state);
+        return XSAN_ERROR_RESOURCE_UNAVAILABLE;
+    }
+    xsan_disk_id_t target_disk_id = dg->disk_ids[0];
+    xsan_disk_t *target_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, target_disk_id);
+    if (!target_disk) {
+        XSAN_LOG_ERROR("Volume %s: First disk (ID: %s) of group '%s' not found.",
+                       vol->name, spdk_uuid_get_string((struct spdk_uuid*)&target_disk_id.data[0]), dg->name);
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    if (target_disk->state != XSAN_STORAGE_STATE_ONLINE) {
+         XSAN_LOG_ERROR("Volume %s: Target disk '%s' (ID: %s) in group '%s' is not online (State: %d).",
+                       vol->name, target_disk->bdev_name, spdk_uuid_get_string((struct spdk_uuid*)&target_disk_id.data[0]),
+                       dg->name, target_disk->state);
+        return XSAN_ERROR_RESOURCE_UNAVAILABLE;
+    }
+    if (target_disk->block_size_bytes == 0) {
+        XSAN_LOG_ERROR("Volume %s: Target disk '%s' (ID: %s) has zero block size.", vol->name, target_disk->bdev_name, spdk_uuid_get_string((struct spdk_uuid*)&target_disk_id.data[0]));
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    if (vol->num_blocks > target_disk->num_blocks) {
+         XSAN_LOG_WARN("Volume %s (blocks: %lu) is larger than its target disk '%s' (blocks: %lu). Mapping might fail for higher LBAs.",
+                       vol->name, vol->num_blocks, target_disk->bdev_name, target_disk->num_blocks);
+    }
+    memcpy(out_disk_id, &target_disk->id, sizeof(xsan_disk_id_t));
+    *out_physical_block_idx = logical_block_idx;
+    *out_physical_block_size = target_disk->block_size_bytes;
+    return XSAN_OK;
+}
+
+// This callback is set as io_req->user_cb and is called by the xsan_io layer
+// (specifically, by the SPDK IO completion handler which then calls io_req->user_cb)
+// after the SPDK bdev I/O completes.
+static void _xsan_physical_io_complete_cb(void *cb_arg_from_io_layer, xsan_error_t status) {
+    // cb_arg_from_io_layer is actually the xsan_io_request_t* itself, as setup by xsan_io_submit_request_to_bdev
+    xsan_io_request_t *io_req = (xsan_io_request_t *)cb_arg_from_io_layer;
+    if (!io_req || !io_req->user_cb_arg) { // io_req->user_cb_arg should be our xsan_vm_physical_io_ctx_t*
+        XSAN_LOG_ERROR("Physical I/O complete with NULL io_req or user_cb_arg (phys_io_ctx)!");
+        if (io_req) {
+            // This is tricky: if user_cb_arg is missing, we don't know the upper callback.
+            // xsan_io_request_free should ideally be called. This indicates a programming error.
+        }
+        return;
+    }
+
+    xsan_vm_physical_io_ctx_t *phys_io_ctx = (xsan_vm_physical_io_ctx_t *)io_req->user_cb_arg;
+
+    if (phys_io_ctx->is_read_op && status == XSAN_OK) {
+        // In xsan_io_submit_request_to_bdev, if dma_buffer_is_internal is true,
+        // data is read into io_req->dma_buffer. If dma_buffer_is_internal is false,
+        // data is read directly into io_req->user_buffer (which is original_user_buffer).
+        // So, copy is only needed if dma_buffer_is_internal was true.
+        if (io_req->dma_buffer && phys_io_ctx->original_user_buffer && io_req->dma_buffer_is_internal) {
+            memcpy(phys_io_ctx->original_user_buffer, io_req->dma_buffer, phys_io_ctx->length_bytes);
+            XSAN_LOG_DEBUG("Read data copied from DMA to user buffer for vol %s, len %lu",
+                spdk_uuid_get_string((struct spdk_uuid*)&phys_io_ctx->volume_id_for_log.data[0]), phys_io_ctx->length_bytes);
+        } else if (io_req->dma_buffer_is_internal && (!io_req->dma_buffer || !phys_io_ctx->original_user_buffer)) {
+             XSAN_LOG_ERROR("Read success for vol %s, but data copy failed due to missing buffers/info (dma_is_internal=%d, dma_buf=%p, user_buf=%p).",
+                spdk_uuid_get_string((struct spdk_uuid*)&phys_io_ctx->volume_id_for_log.data[0]),
+                io_req->dma_buffer_is_internal, io_req->dma_buffer, phys_io_ctx->original_user_buffer);
+             status = XSAN_ERROR_INTERNAL;
+        }
+        // If !io_req->dma_buffer_is_internal, data was read directly into phys_io_ctx->original_user_buffer, so no copy needed.
+    }
+
+    if (phys_io_ctx->actual_upper_cb) {
+        phys_io_ctx->actual_upper_cb(phys_io_ctx->actual_upper_cb_arg, status);
+    }
+    // xsan_io_request_free is called by _xsan_io_spdk_completion_cb after this user_cb returns.
+    // So, we only need to free the phys_io_ctx wrapper.
+    XSAN_FREE(phys_io_ctx);
+}
+
+static xsan_error_t _xsan_volume_submit_single_io_attempt(
+    xsan_volume_manager_t *vm,
+    xsan_volume_id_t volume_id,
+    uint64_t logical_byte_offset,
+    uint64_t length_bytes,
+    void *original_user_buffer,
+    bool is_read_op,
+    xsan_user_io_completion_cb_t upper_completion_cb,
+    void *upper_completion_cb_arg) {
+
+    if (!vm || !vm->initialized) return XSAN_ERROR_INVALID_PARAM;
+    xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id);
+    if (!vol) return XSAN_ERROR_NOT_FOUND;
+    if (vol->block_size_bytes == 0 ||
+        (logical_byte_offset % vol->block_size_bytes != 0) ||
+        (length_bytes % vol->block_size_bytes != 0) ||
+        (length_bytes == 0) ||
+        (logical_byte_offset + length_bytes > vol->size_bytes)) {
+        return XSAN_ERROR_INVALID_PARAM_ALIGNMENT;
+    }
+    uint64_t logical_block_idx = logical_byte_offset / vol->block_size_bytes;
+    xsan_disk_id_t physical_disk_id;
+    uint64_t physical_start_block_idx;
+    uint32_t physical_block_size_bytes;
+    xsan_error_t map_err = xsan_volume_map_lba_to_physical(vm, volume_id, logical_block_idx,
+                                                         &physical_disk_id, &physical_start_block_idx,
+                                                         &physical_block_size_bytes);
+    if (map_err != XSAN_OK) {
+        XSAN_LOG_ERROR("Vol %s: Failed to map LBA_idx %lu: %s",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), logical_block_idx, xsan_error_string(map_err));
+        return map_err;
+    }
+    if (physical_block_size_bytes == 0) {
+        XSAN_LOG_ERROR("Vol %s: Mapped physical disk has zero block size.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    if (length_bytes % physical_block_size_bytes != 0) {
+        XSAN_LOG_ERROR("Vol %s: I/O length %lu is not a multiple of physical block size %u for mapped LBA %lu.",
+                        spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), length_bytes, physical_block_size_bytes, logical_block_idx);
+        return XSAN_ERROR_INVALID_PARAM_ALIGNMENT;
+    }
+    xsan_disk_t *physical_disk = xsan_disk_manager_find_disk_by_id(vm->disk_manager, physical_disk_id);
+    if (!physical_disk) {
+        XSAN_LOG_ERROR("Vol %s: Physical disk (ID: %s) for LBA map not found.",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), spdk_uuid_get_string((struct spdk_uuid*)&physical_disk_id.data[0]));
+        return XSAN_ERROR_STORAGE_GENERIC;
+    }
+    if (!physical_disk->bdev_descriptor) {
+        XSAN_LOG_ERROR("Vol %s: Physical disk '%s' (ID: %s) for LBA map has no bdev descriptor.",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), physical_disk->bdev_name, spdk_uuid_get_string((struct spdk_uuid*)&physical_disk_id.data[0]));
+        return XSAN_ERROR_RESOURCE_UNAVAILABLE;
+    }
+
+    xsan_vm_physical_io_ctx_t *phys_io_ctx = XSAN_MALLOC(sizeof(xsan_vm_physical_io_ctx_t));
+    if(!phys_io_ctx) return XSAN_ERROR_OUT_OF_MEMORY;
+
+    phys_io_ctx->actual_upper_cb = upper_completion_cb;
+    phys_io_ctx->actual_upper_cb_arg = upper_completion_cb_arg;
+    phys_io_ctx->original_user_buffer = original_user_buffer;
+    phys_io_ctx->is_read_op = is_read_op;
+    phys_io_ctx->length_bytes = length_bytes;
+    memcpy(&phys_io_ctx->volume_id_for_log, &volume_id, sizeof(xsan_volume_id_t));
+
+    xsan_io_request_t *io_req = xsan_io_request_create(volume_id,
+                                                      original_user_buffer,
+                                                      physical_start_block_idx * physical_block_size_bytes,
+                                                      length_bytes,
+                                                      physical_block_size_bytes,
+                                                      is_read_op,
+                                                      _xsan_physical_io_complete_cb,
+                                                      phys_io_ctx);
+    if (!io_req) {
+        XSAN_FREE(phys_io_ctx);
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+    phys_io_ctx->io_req = io_req;
+
+    memcpy(&io_req->target_disk_id, &physical_disk->id, sizeof(xsan_disk_id_t));
+    xsan_strcpy_safe(io_req->target_bdev_name, physical_disk->bdev_name, XSAN_MAX_NAME_LEN);
+    io_req->bdev_desc = physical_disk->bdev_descriptor;
+    io_req->io_channel = NULL;
+    io_req->own_spdk_resources = false;
+
+    xsan_error_t submit_err = xsan_io_submit_request_to_bdev(io_req);
+
+    if (submit_err != XSAN_OK) {
+        XSAN_LOG_ERROR("Vol %s: Failed to submit %s to bdev '%s' via xsan_io: %s",
+                       spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]),
+                       is_read_op ? "read" : "write",
+                       physical_disk->bdev_name, xsan_error_string(submit_err));
+        // xsan_io_submit_request_to_bdev should free io_req on sync failure path (as per its current code)
+        // so we only need to free phys_io_ctx
+        XSAN_FREE(phys_io_ctx);
+        return submit_err;
+    }
+    return XSAN_OK;
+}
+
+
 static void _xsan_local_replica_write_complete_cb(void *cb_arg, xsan_error_t status) {
     xsan_replicated_io_ctx_t *rep_ctx = cb_arg; if(!rep_ctx)return;
     xsan_volume_t *vol = xsan_volume_get_by_id(g_xsan_volume_manager_instance, rep_ctx->volume_id);
-    if(vol && vol->actual_replica_count > 0){ // Update local replica state
+    if(vol && vol->actual_replica_count > 0){
+        pthread_mutex_lock(&g_xsan_volume_manager_instance->lock);
         vol->replica_nodes[0].state = (status == XSAN_OK) ? XSAN_STORAGE_STATE_ONLINE : XSAN_STORAGE_STATE_FAILED;
         if(status == XSAN_OK) vol->replica_nodes[0].last_successful_contact_time_us = _get_current_time_us();
-        // No need to lock vm->lock here if _xsan_volume_update_overall_state handles its own locking for save_meta
-        // or if this callback is already on a thread that serializes access to 'vol'.
-        // _xsan_volume_update_overall_state(g_xsan_volume_manager_instance, vol); // This will be called in check_completion
+        pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
     }
     if(status==XSAN_OK)__sync_fetch_and_add(&rep_ctx->successful_writes,1); else {__sync_fetch_and_add(&rep_ctx->failed_writes,1); if(rep_ctx->final_status==XSAN_OK)rep_ctx->final_status=status;}
     rep_ctx->local_io_req = NULL; _xsan_check_replicated_write_completion(rep_ctx);
 }
-static void _xsan_remote_replica_connect_then_send_cb(struct spdk_sock *sock, int status, void *cb_arg) { /* ... as before, on failure update replica state ... */
-    xsan_per_replica_op_ctx_t *p_ctx = cb_arg; if(!p_ctx || !p_ctx->parent_rep_ctx || !p_ctx->request_msg_to_send){ /* free */ return;}
+static void _xsan_remote_replica_connect_then_send_cb(struct spdk_sock *sock, int status, void *cb_arg) {
+    xsan_per_replica_op_ctx_t *p_ctx = cb_arg; if(!p_ctx || !p_ctx->parent_rep_ctx || !p_ctx->request_msg_to_send){ return;}
     xsan_replicated_io_ctx_t* rep_ctx = p_ctx->parent_rep_ctx;
     xsan_volume_t *vol = xsan_volume_get_by_id(g_xsan_volume_manager_instance, rep_ctx->volume_id);
-    uint32_t replica_idx = XSAN_MAX_REPLICAS; // Find which replica this is for state update
-    if(vol){ for(uint32_t i=1; i<vol->actual_replica_count; ++i) if(memcmp(&vol->replica_nodes[i], &p_ctx->replica_location_info, sizeof(xsan_replica_location_t))==0) {replica_idx=i; break;} }
+    uint32_t replica_idx = XSAN_MAX_REPLICAS;
+    if(vol){
+        pthread_mutex_lock(&g_xsan_volume_manager_instance->lock);
+        for(uint32_t i=1; i<vol->actual_replica_count; ++i) if(memcmp(&vol->replica_nodes[i].node_id, &p_ctx->replica_location_info.node_id, sizeof(xsan_node_id_t))==0) {replica_idx=i; break;}
+        pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
+    }
 
     if(status==0 && sock){ p_ctx->connected_sock = sock; xsan_error_t s_err = xsan_node_comm_send_msg(sock, p_ctx->request_msg_to_send, _xsan_remote_replica_request_send_actual_cb, p_ctx); if(s_err!=XSAN_OK){ _xsan_remote_replica_request_send_actual_cb(s_err, p_ctx);}}
     else {
-        if(vol && replica_idx < XSAN_MAX_REPLICAS) vol->replica_nodes[replica_idx].state = XSAN_STORAGE_STATE_OFFLINE;
+        if(vol && replica_idx < XSAN_MAX_REPLICAS) {
+            pthread_mutex_lock(&g_xsan_volume_manager_instance->lock);
+            vol->replica_nodes[replica_idx].state = XSAN_STORAGE_STATE_OFFLINE;
+            pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
+        }
         __sync_fetch_and_add(&rep_ctx->failed_writes,1); if(rep_ctx->final_status==XSAN_OK)rep_ctx->final_status=xsan_error_from_errno(-status);
         xsan_protocol_message_destroy(p_ctx->request_msg_to_send); XSAN_FREE(p_ctx);
         _xsan_check_replicated_write_completion(rep_ctx);
     }
 }
-static void _xsan_remote_replica_request_send_actual_cb(int comm_status, void *cb_arg) { /* ... as before, on failure update replica state ... */
+static void _xsan_remote_replica_request_send_actual_cb(int comm_status, void *cb_arg) {
     xsan_per_replica_op_ctx_t *p_ctx = cb_arg; if(!p_ctx || !p_ctx->parent_rep_ctx){if(p_ctx)XSAN_FREE(p_ctx);return;}
     xsan_replicated_io_ctx_t* rep_ctx = p_ctx->parent_rep_ctx;
     xsan_volume_t *vol = xsan_volume_get_by_id(g_xsan_volume_manager_instance, rep_ctx->volume_id);
     uint32_t replica_idx = XSAN_MAX_REPLICAS;
-    if(vol){ for(uint32_t i=1; i<vol->actual_replica_count; ++i) if(memcmp(&vol->replica_nodes[i], &p_ctx->replica_location_info, sizeof(xsan_replica_location_t))==0) {replica_idx=i; break;} }
+    if(vol){
+        pthread_mutex_lock(&g_xsan_volume_manager_instance->lock);
+        for(uint32_t i=1; i<vol->actual_replica_count; ++i) if(memcmp(&vol->replica_nodes[i].node_id, &p_ctx->replica_location_info.node_id, sizeof(xsan_node_id_t))==0) {replica_idx=i; break;}
+        pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
+    }
 
     if(comm_status!=0){
-        if(vol && replica_idx < XSAN_MAX_REPLICAS) vol->replica_nodes[replica_idx].state = XSAN_STORAGE_STATE_OFFLINE; // Send failed
+        if(vol && replica_idx < XSAN_MAX_REPLICAS) {
+            pthread_mutex_lock(&g_xsan_volume_manager_instance->lock);
+            vol->replica_nodes[replica_idx].state = XSAN_STORAGE_STATE_OFFLINE;
+            pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
+        }
         __sync_fetch_and_add(&rep_ctx->failed_writes,1); if(rep_ctx->final_status==XSAN_OK)rep_ctx->final_status=xsan_error_from_errno(-comm_status); _xsan_check_replicated_write_completion(rep_ctx);
     }
     if(p_ctx->request_msg_to_send) xsan_protocol_message_destroy(p_ctx->request_msg_to_send);
     XSAN_FREE(p_ctx);
 }
 
-void xsan_volume_manager_process_replica_write_response(xsan_volume_manager_t *vm, uint64_t tid, xsan_node_id_t resp_node_id, xsan_error_t repl_op_status) { /* ... as before, update replica state ... */
+void xsan_volume_manager_process_replica_write_response(xsan_volume_manager_t *vm, uint64_t tid, xsan_node_id_t resp_node_id, xsan_error_t repl_op_status) {
     if (!vm || !vm->initialized) return;
     pthread_mutex_lock(&vm->pending_ios_lock); xsan_replicated_io_ctx_t *rep_ctx = xsan_hashtable_get(vm->pending_replicated_ios, &tid); pthread_mutex_unlock(&vm->pending_ios_lock);
     if (rep_ctx) {
         xsan_volume_t *vol = xsan_volume_get_by_id(vm, rep_ctx->volume_id);
-        if(vol){ for(uint32_t i=1; i<vol->actual_replica_count; ++i){ if(spdk_uuid_compare((struct spdk_uuid*)&vol->replica_nodes[i].node_id.data[0], (struct spdk_uuid*)&resp_node_id.data[0])==0){
-            vol->replica_nodes[i].state = (repl_op_status==XSAN_OK) ? XSAN_STORAGE_STATE_ONLINE : XSAN_STORAGE_STATE_DEGRADED; // Or FAILED
-            if(repl_op_status==XSAN_OK) vol->replica_nodes[i].last_successful_contact_time_us = _get_current_time_us();
-            break;
-        }}}
+        if(vol){
+            pthread_mutex_lock(&vm->lock);
+            for(uint32_t i=1; i<vol->actual_replica_count; ++i){
+                if(spdk_uuid_compare((struct spdk_uuid*)&vol->replica_nodes[i].node_id.data[0], (struct spdk_uuid*)&resp_node_id.data[0])==0){
+                    vol->replica_nodes[i].state = (repl_op_status==XSAN_OK) ? XSAN_STORAGE_STATE_ONLINE : XSAN_STORAGE_STATE_DEGRADED;
+                    if(repl_op_status==XSAN_OK) vol->replica_nodes[i].last_successful_contact_time_us = _get_current_time_us();
+                    break;
+                }
+            }
+            pthread_mutex_unlock(&vm->lock);
+        }
         if (repl_op_status == XSAN_OK) __sync_fetch_and_add(&rep_ctx->successful_writes, 1);
         else { __sync_fetch_and_add(&rep_ctx->failed_writes, 1); if (rep_ctx->final_status == XSAN_OK) rep_ctx->final_status = repl_op_status; }
         _xsan_check_replicated_write_completion(rep_ctx);
     } else { XSAN_LOG_WARN("No pending rep IO ctx for TID %lu from node %s.", tid, spdk_uuid_get_string((struct spdk_uuid*)&resp_node_id.data[0]));}
 }
 
-static xsan_error_t _xsan_volume_submit_single_io_attempt( /* ... */ ) { /* ... as before ... */ return XSAN_OK;}
-xsan_error_t xsan_volume_read_async(xsan_volume_manager_t *vm, xsan_volume_id_t vol_id, uint64_t log_byte_off, uint64_t len_bytes, void *u_buf, xsan_user_io_completion_cb_t u_cb, void *u_cb_arg) { /* ... uses _xsan_try_read_from_next_replica ... */
+xsan_error_t xsan_volume_read_async(xsan_volume_manager_t *vm, xsan_volume_id_t vol_id, uint64_t log_byte_off, uint64_t len_bytes, void *u_buf, xsan_user_io_completion_cb_t u_cb, void *u_cb_arg) {
     if (!vm || !vm->initialized || !u_buf || len_bytes==0 || !u_cb) return XSAN_ERROR_INVALID_PARAM;
     xsan_volume_t *vol = xsan_volume_get_by_id(vm, vol_id); if(!vol) return XSAN_ERROR_NOT_FOUND;
-    if (vol->block_size_bytes==0 || (log_byte_off % vol->block_size_bytes !=0) || (len_bytes % vol->block_size_bytes !=0) || (log_byte_off+len_bytes > vol->size_bytes)) return XSAN_ERROR_INVALID_PARAM;
+    if (vol->block_size_bytes==0 || (log_byte_off % vol->block_size_bytes !=0) || (len_bytes % vol->block_size_bytes !=0) || (log_byte_off+len_bytes > vol->size_bytes)) return XSAN_ERROR_INVALID_PARAM_ALIGNMENT;
     static uint64_t s_rtid_ctr = 6000; uint64_t tid = __sync_fetch_and_add(&s_rtid_ctr,1);
     xsan_replica_read_coordinator_ctx_t *coord = xsan_replica_read_coordinator_ctx_create(vol,u_buf,log_byte_off,len_bytes,u_cb,u_cb_arg,tid);
     if(!coord) return XSAN_ERROR_OUT_OF_MEMORY;
     _xsan_try_read_from_next_replica(coord); return XSAN_OK;
 }
-static void _xsan_try_read_from_next_replica(xsan_replica_read_coordinator_ctx_t *coord_ctx) { /* ... as before, but local read cb is _xsan_replica_read_attempt_complete_cb ... */
+static void _xsan_try_read_from_next_replica(xsan_replica_read_coordinator_ctx_t *coord_ctx) {
     if(!coord_ctx || !coord_ctx->vol){ if(coord_ctx){if(coord_ctx->original_user_cb)coord_ctx->original_user_cb(coord_ctx->original_user_cb_arg, XSAN_ERROR_INVALID_PARAM); xsan_replica_read_coordinator_ctx_free(coord_ctx);} return;}
-    if(coord_ctx->current_replica_idx_to_try >= (int)coord_ctx->vol->actual_replica_count || coord_ctx->current_replica_idx_to_try >= XSAN_MAX_REPLICAS) { /* All failed */
+    if(coord_ctx->current_replica_idx_to_try >= (int)coord_ctx->vol->actual_replica_count || coord_ctx->current_replica_idx_to_try >= XSAN_MAX_REPLICAS) {
         if(coord_ctx->original_user_cb)coord_ctx->original_user_cb(coord_ctx->original_user_cb_arg, coord_ctx->last_attempt_status);
         pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock); xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replica_reads, &coord_ctx->transaction_id); pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock);
         xsan_replica_read_coordinator_ctx_free(coord_ctx); return;
     }
-    int cur_idx = coord_ctx->current_replica_idx_to_try; xsan_replica_location_t *loc = &coord_ctx->vol->replica_nodes[cur_idx];
-    bool is_local = (cur_idx==0); // Simplified local check
-    if(is_local){ coord_ctx->last_attempt_status = _xsan_volume_submit_single_io_attempt(g_xsan_volume_manager_instance, coord_ctx->vol->id, coord_ctx->logical_byte_offset, coord_ctx->length_bytes, coord_ctx->user_buffer, true, _xsan_replica_read_attempt_complete_cb, coord_ctx); if(coord_ctx->last_attempt_status!=XSAN_OK){coord_ctx->current_replica_idx_to_try++; _xsan_try_read_from_next_replica(coord_ctx);}}
-    else { /* Remote read: setup DMA, per_replica_op_ctx, add to pending_replica_reads, connect/send */
-        if(!coord_ctx->internal_dma_buffer){coord_ctx->internal_dma_buffer=xsan_bdev_dma_malloc(coord_ctx->length_bytes,4096); if(!coord_ctx->internal_dma_buffer){coord_ctx->last_attempt_status=XSAN_ERROR_OUT_OF_MEMORY; coord_ctx->current_replica_idx_to_try++; _xsan_try_read_from_next_replica(coord_ctx);return;} coord_ctx->internal_dma_buffer_allocated=true; coord_ctx->internal_dma_buffer_size=coord_ctx->length_bytes;}
-        xsan_per_replica_op_ctx_t *rop_ctx = XSAN_MALLOC(sizeof(*rop_ctx)); if(!rop_ctx){/* ... */ _xsan_try_read_from_next_replica(coord_ctx);return;} memset(rop_ctx,0,sizeof(*rop_ctx)); rop_ctx->parent_rep_ctx=(void*)coord_ctx; memcpy(&rop_ctx->replica_location_info,loc,sizeof(*loc));
-        xsan_replica_read_req_payload_t req_pl; memcpy(&req_pl.volume_id,&coord_ctx->vol->id,sizeof(req_pl.volume_id)); req_pl.block_lba_on_volume=coord_ctx->logical_byte_offset/coord_ctx->vol->block_size_bytes; req_pl.num_blocks=coord_ctx->length_bytes/coord_ctx->vol->block_size_bytes;
+    int cur_idx = coord_ctx->current_replica_idx_to_try;
+    xsan_replica_location_t *loc = NULL;
+    pthread_mutex_lock(&g_xsan_volume_manager_instance->lock); // Lock to safely access vol->replica_nodes
+    if (cur_idx < (int)coord_ctx->vol->actual_replica_count) { // Double check after lock
+        loc = &coord_ctx->vol->replica_nodes[cur_idx];
+    }
+    pthread_mutex_unlock(&g_xsan_volume_manager_instance->lock);
+
+    if (!loc) { // Should not happen if current_replica_idx_to_try is managed correctly
+        coord_ctx->last_attempt_status = XSAN_ERROR_INTERNAL;
+        coord_ctx->current_replica_idx_to_try++;
+         _xsan_try_read_from_next_replica(coord_ctx);
+        return;
+    }
+
+    bool is_local = (cur_idx==0);
+
+    XSAN_LOG_DEBUG("Read attempt for vol %s, TID %lu, replica_idx %d (local: %d, IP: %s)",
+                   spdk_uuid_get_string((struct spdk_uuid*)&coord_ctx->vol->id.data[0]), coord_ctx->transaction_id, cur_idx, is_local, loc->node_ip_addr);
+
+    if(is_local){
+        coord_ctx->last_attempt_status = _xsan_volume_submit_single_io_attempt(
+                                            g_xsan_volume_manager_instance,
+                                            coord_ctx->vol->id,
+                                            coord_ctx->logical_byte_offset,
+                                            coord_ctx->length_bytes,
+                                            coord_ctx->user_buffer,
+                                            true,
+                                            _xsan_replica_read_attempt_complete_cb,
+                                            coord_ctx);
+        if(coord_ctx->last_attempt_status!=XSAN_OK){
+            coord_ctx->current_replica_idx_to_try++;
+            _xsan_try_read_from_next_replica(coord_ctx);
+        }
+    } else {
+        if(!coord_ctx->internal_dma_buffer && coord_ctx->length_bytes > 0){
+            size_t align = 4096;
+            xsan_disk_group_t *dg = xsan_disk_manager_find_disk_group_by_id(g_xsan_volume_manager_instance->disk_manager, coord_ctx->vol->source_group_id);
+            if (dg && dg->disk_count > 0) {
+                xsan_disk_t *disk0 = xsan_disk_manager_find_disk_by_id(g_xsan_volume_manager_instance->disk_manager, dg->disk_ids[0]);
+                if (disk0 && disk0->bdev_name[0] != '\0') align = xsan_bdev_get_buf_align(disk0->bdev_name);
+            }
+            coord_ctx->internal_dma_buffer=xsan_bdev_dma_malloc(coord_ctx->length_bytes, align);
+            if(!coord_ctx->internal_dma_buffer){
+                coord_ctx->last_attempt_status=XSAN_ERROR_OUT_OF_MEMORY;
+                coord_ctx->current_replica_idx_to_try++;
+                _xsan_try_read_from_next_replica(coord_ctx);
+                return;
+            }
+            coord_ctx->internal_dma_buffer_allocated=true;
+            coord_ctx->internal_dma_buffer_size=coord_ctx->length_bytes;
+        }
+        xsan_per_replica_op_ctx_t *rop_ctx = XSAN_MALLOC(sizeof(*rop_ctx));
+        if(!rop_ctx){ coord_ctx->last_attempt_status=XSAN_ERROR_OUT_OF_MEMORY; coord_ctx->current_replica_idx_to_try++; _xsan_try_read_from_next_replica(coord_ctx); return;}
+        memset(rop_ctx,0,sizeof(*rop_ctx));
+        rop_ctx->parent_rep_ctx=(void*)coord_ctx;
+        memcpy(&rop_ctx->replica_location_info,loc,sizeof(xsan_replica_location_t));
+        xsan_replica_read_req_payload_t req_pl;
+        memcpy(&req_pl.volume_id,&coord_ctx->vol->id,sizeof(req_pl.volume_id));
+        req_pl.block_lba_on_volume=coord_ctx->logical_byte_offset/coord_ctx->vol->block_size_bytes;
+        req_pl.num_blocks=coord_ctx->length_bytes/coord_ctx->vol->block_size_bytes;
         rop_ctx->request_msg_to_send = xsan_protocol_message_create(XSAN_MSG_TYPE_REPLICA_READ_BLOCK_REQ, coord_ctx->transaction_id, &req_pl, sizeof(req_pl));
-        if(!rop_ctx->request_msg_to_send){XSAN_FREE(rop_ctx); /* ... */ _xsan_try_read_from_next_replica(coord_ctx);return;}
+        if(!rop_ctx->request_msg_to_send){
+            XSAN_FREE(rop_ctx);
+            coord_ctx->last_attempt_status=XSAN_ERROR_OUT_OF_MEMORY;
+            coord_ctx->current_replica_idx_to_try++;
+            _xsan_try_read_from_next_replica(coord_ctx);
+            return;
+        }
         coord_ctx->current_remote_op_ctx = rop_ctx;
-        pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock); xsan_hashtable_put(g_xsan_volume_manager_instance->pending_replica_reads, &coord_ctx->transaction_id, coord_ctx); pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock);
+        pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock);
+        xsan_hashtable_put(g_xsan_volume_manager_instance->pending_replica_reads, &coord_ctx->transaction_id, coord_ctx);
+        pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock);
         struct spdk_sock *sock = xsan_node_comm_get_active_connection(loc->node_ip_addr,loc->node_comm_port);
-        if(sock) _xsan_remote_replica_read_connect_then_send_cb(sock,0,rop_ctx); else xsan_node_comm_connect(loc->node_ip_addr,loc->node_comm_port,_xsan_remote_replica_read_connect_then_send_cb,rop_ctx);
+        if(sock) _xsan_remote_replica_read_connect_then_send_cb(sock,0,rop_ctx);
+        else xsan_node_comm_connect(loc->node_ip_addr,loc->node_comm_port,_xsan_remote_replica_read_connect_then_send_cb,rop_ctx);
     }
 }
-static void _xsan_replica_read_attempt_complete_cb(void *cb_arg, xsan_error_t status) { /* ... as before, on success copy from internal_dma_buffer ... */
+static void _xsan_replica_read_attempt_complete_cb(void *cb_arg, xsan_error_t status) {
     xsan_replica_read_coordinator_ctx_t*ctx=cb_arg; if(!ctx)return;
-    if(status==XSAN_OK){ if(ctx->internal_dma_buffer_allocated&&ctx->internal_dma_buffer&&ctx->user_buffer)memcpy(ctx->user_buffer,ctx->internal_dma_buffer,ctx->length_bytes); ctx->original_user_cb(ctx->original_user_cb_arg,XSAN_OK); pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock);xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replica_reads,&ctx->transaction_id);pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock); xsan_replica_read_coordinator_ctx_free(ctx);}
-    else{ctx->last_attempt_status=status; ctx->current_replica_idx_to_try++; if(ctx->current_remote_op_ctx){if(ctx->current_remote_op_ctx->request_msg_to_send)xsan_protocol_message_destroy(ctx->current_remote_op_ctx->request_msg_to_send);XSAN_FREE(ctx->current_remote_op_ctx);ctx->current_remote_op_ctx=NULL;} _xsan_try_read_from_next_replica(ctx);}
+    XSAN_LOG_DEBUG("Replica read attempt for vol %s, TID %lu, replica_idx %d completed with status %d",
+                   spdk_uuid_get_string((struct spdk_uuid*)&ctx->vol->id.data[0]), ctx->transaction_id, ctx->current_replica_idx_to_try, status);
+    if(status==XSAN_OK){
+        bool was_remote_attempt = (ctx->current_replica_idx_to_try > 0);
+        if (was_remote_attempt && ctx->internal_dma_buffer_allocated && ctx->internal_dma_buffer && ctx->user_buffer) {
+             memcpy(ctx->user_buffer, ctx->internal_dma_buffer, ctx->length_bytes);
+        }
+        ctx->original_user_cb(ctx->original_user_cb_arg,XSAN_OK);
+        pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock);xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replica_reads,&ctx->transaction_id);pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock);
+        xsan_replica_read_coordinator_ctx_free(ctx);
+    } else {
+        ctx->last_attempt_status=status;
+        ctx->current_replica_idx_to_try++;
+        if(ctx->current_remote_op_ctx){
+            if(ctx->current_remote_op_ctx->request_msg_to_send)xsan_protocol_message_destroy(ctx->current_remote_op_ctx->request_msg_to_send);
+            XSAN_FREE(ctx->current_remote_op_ctx);
+            ctx->current_remote_op_ctx=NULL;
+        }
+        _xsan_try_read_from_next_replica(ctx);
+    }
 }
-static void _xsan_remote_replica_read_req_send_complete_cb(int comm_status, void *cb_arg) { /* ... as before ... */
+static void _xsan_remote_replica_read_req_send_complete_cb(int comm_status, void *cb_arg) {
     xsan_per_replica_op_ctx_t*p_ctx=cb_arg;if(!p_ctx||!p_ctx->parent_rep_ctx){if(p_ctx)XSAN_FREE(p_ctx);return;}
     xsan_replica_read_coordinator_ctx_t*coord_ctx=(xsan_replica_read_coordinator_ctx_t*)p_ctx->parent_rep_ctx;
-    if(comm_status!=0){ pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock);xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replica_reads,&coord_ctx->transaction_id);pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock); _xsan_replica_read_attempt_complete_cb(coord_ctx,xsan_error_from_errno(-comm_status));}
-    if(p_ctx->request_msg_to_send)xsan_protocol_message_destroy(p_ctx->request_msg_to_send); XSAN_FREE(p_ctx); coord_ctx->current_remote_op_ctx=NULL;
+    if(comm_status!=0){
+        _xsan_replica_read_attempt_complete_cb(coord_ctx,xsan_error_from_errno(-comm_status));
+    }
+    if(p_ctx->request_msg_to_send)xsan_protocol_message_destroy(p_ctx->request_msg_to_send);
+    XSAN_FREE(p_ctx);
+    coord_ctx->current_remote_op_ctx=NULL;
 }
-static void _xsan_remote_replica_read_connect_then_send_cb(struct spdk_sock *sock, int status, void *cb_arg) { /* ... as before ... */
+static void _xsan_remote_replica_read_connect_then_send_cb(struct spdk_sock *sock, int status, void *cb_arg) {
     xsan_per_replica_op_ctx_t*p_ctx=cb_arg;if(!p_ctx||!p_ctx->parent_rep_ctx||!p_ctx->request_msg_to_send){if(p_ctx&&p_ctx->request_msg_to_send)xsan_protocol_message_destroy(p_ctx->request_msg_to_send);if(p_ctx)XSAN_FREE(p_ctx);return;}
     xsan_replica_read_coordinator_ctx_t*coord_ctx=(xsan_replica_read_coordinator_ctx_t*)p_ctx->parent_rep_ctx;
-    if(status==0&&sock){p_ctx->connected_sock=sock; xsan_error_t s_err=xsan_node_comm_send_msg(sock,p_ctx->request_msg_to_send,_xsan_remote_replica_read_req_send_complete_cb,p_ctx); if(s_err!=XSAN_OK)_xsan_remote_replica_read_req_send_complete_cb(s_err,p_ctx);}
-    else{pthread_mutex_lock(&g_xsan_volume_manager_instance->pending_ios_lock);xsan_hashtable_remove(g_xsan_volume_manager_instance->pending_replica_reads,&coord_ctx->transaction_id);pthread_mutex_unlock(&g_xsan_volume_manager_instance->pending_ios_lock); _xsan_replica_read_attempt_complete_cb(coord_ctx,xsan_error_from_errno(-status)); if(p_ctx->request_msg_to_send)xsan_protocol_message_destroy(p_ctx->request_msg_to_send);XSAN_FREE(p_ctx); coord_ctx->current_remote_op_ctx=NULL;}
+    if(status==0&&sock){
+        p_ctx->connected_sock=sock;
+        xsan_error_t s_err=xsan_node_comm_send_msg(sock,p_ctx->request_msg_to_send,_xsan_remote_replica_read_req_send_complete_cb,p_ctx);
+        if(s_err!=XSAN_OK) _xsan_remote_replica_read_req_send_complete_cb(s_err,p_ctx);
+    } else {
+        _xsan_replica_read_attempt_complete_cb(coord_ctx,xsan_error_from_errno(-status));
+    }
 }
-void xsan_volume_manager_process_replica_read_response(xsan_volume_manager_t *vm, uint64_t tid, xsan_node_id_t r_nid, xsan_error_t r_op_status, const unsigned char *data, uint32_t data_len) { /* ... as before ... */
+void xsan_volume_manager_process_replica_read_response(xsan_volume_manager_t *vm, uint64_t tid, xsan_node_id_t r_nid, xsan_error_t r_op_status, const unsigned char *data, uint32_t data_len) {
     if(!vm||!vm->initialized)return;
-    pthread_mutex_lock(&vm->pending_ios_lock); xsan_replica_read_coordinator_ctx_t*ctx=xsan_hashtable_remove(vm->pending_replica_reads,&tid); pthread_mutex_unlock(&vm->pending_ios_lock);
-    if(ctx){if(r_op_status==XSAN_OK){if(data&&data_len==ctx->length_bytes){if(!ctx->internal_dma_buffer){ctx->internal_dma_buffer=xsan_bdev_dma_malloc(ctx->length_bytes,0);if(ctx->internal_dma_buffer){ctx->internal_dma_buffer_allocated=true;ctx->internal_dma_buffer_size=ctx->length_bytes;}else{r_op_status=XSAN_ERROR_OUT_OF_MEMORY;}} if(r_op_status==XSAN_OK)memcpy(ctx->internal_dma_buffer,data,data_len);}else{r_op_status=XSAN_ERROR_PROTOCOL_GENERIC;}}_xsan_replica_read_attempt_complete_cb(ctx,r_op_status);}
+    pthread_mutex_lock(&vm->pending_ios_lock); xsan_replica_read_coordinator_ctx_t*ctx=xsan_hashtable_get(vm->pending_replica_reads,&tid); pthread_mutex_unlock(&vm->pending_ios_lock);
+    if(ctx){
+        if(r_op_status==XSAN_OK){
+            if(data && data_len == ctx->length_bytes){
+                if(!ctx->internal_dma_buffer){
+                    XSAN_LOG_ERROR("TID %lu: internal_dma_buffer is NULL in process_replica_read_response for vol %s. Allocating.", tid, spdk_uuid_get_string((struct spdk_uuid*)&ctx->vol->id.data[0]));
+                    size_t align = 4096;
+                    xsan_disk_group_t *dg = xsan_disk_manager_find_disk_group_by_id(g_xsan_volume_manager_instance->disk_manager, ctx->vol->source_group_id);
+                    if (dg && dg->disk_count > 0) {
+                        xsan_disk_t *disk0 = xsan_disk_manager_find_disk_by_id(g_xsan_volume_manager_instance->disk_manager, dg->disk_ids[0]);
+                         if (disk0 && disk0->bdev_name[0] != '\0') align = xsan_bdev_get_buf_align(disk0->bdev_name);
+                    }
+                    ctx->internal_dma_buffer=xsan_bdev_dma_malloc(ctx->length_bytes,align);
+                    if(ctx->internal_dma_buffer){ctx->internal_dma_buffer_allocated=true;ctx->internal_dma_buffer_size=ctx->length_bytes;}
+                    else{r_op_status=XSAN_ERROR_OUT_OF_MEMORY;}
+                }
+                if(r_op_status==XSAN_OK && ctx->internal_dma_buffer) memcpy(ctx->internal_dma_buffer,data,data_len);
+            } else {
+                XSAN_LOG_ERROR("TID %lu: Replica read response for vol %s has data len %u, expected %lu, or data is NULL.", tid, spdk_uuid_get_string((struct spdk_uuid*)&ctx->vol->id.data[0]), data_len, ctx->length_bytes);
+                r_op_status=XSAN_ERROR_PROTOCOL_GENERIC;
+            }
+        }
+        // Do not remove from hashtable here, _xsan_replica_read_attempt_complete_cb will do it on final success/failure.
+        _xsan_replica_read_attempt_complete_cb(ctx,r_op_status);
+    } else {
+        XSAN_LOG_WARN("No pending replica read ctx for TID %lu from node %s.", tid, spdk_uuid_get_string((struct spdk_uuid*)&r_nid.data[0]));
+    }
 }
-xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm, xsan_volume_id_t vol_id, uint64_t lbo, uint64_t len, const void *u_buf, xsan_user_io_completion_cb_t u_cb, void *u_cb_arg) { /* ... as before ... */ return XSAN_OK;}
+
+xsan_error_t xsan_volume_write_async(xsan_volume_manager_t *vm,
+                                     xsan_volume_id_t volume_id,
+                                     uint64_t logical_byte_offset,
+                                     uint64_t length_bytes,
+                                     const void *user_buf,
+                                     xsan_user_io_completion_cb_t user_cb,
+                                     void *user_cb_arg) {
+    if (!vm || !vm->initialized || !user_buf || length_bytes == 0 || !user_cb ||
+        spdk_uuid_is_null((struct spdk_uuid*)&volume_id.data[0])) {
+        return XSAN_ERROR_INVALID_PARAM;
+    }
+
+    xsan_volume_t *vol = xsan_volume_get_by_id(vm, volume_id);
+    if (!vol) {
+        XSAN_LOG_ERROR("Volume ID %s not found for write.", spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        return XSAN_ERROR_NOT_FOUND;
+    }
+
+    pthread_mutex_lock(&vm->lock); // Lock to read vol->state and vol->replica_nodes safely
+    xsan_storage_state_t current_vol_state = vol->state;
+    uint32_t current_actual_replica_count = vol->actual_replica_count;
+    xsan_replica_location_t replica_locations_copy[XSAN_MAX_REPLICAS];
+    if (current_actual_replica_count > 0 && current_actual_replica_count <= XSAN_MAX_REPLICAS) {
+         memcpy(replica_locations_copy, vol->replica_nodes, sizeof(xsan_replica_location_t) * current_actual_replica_count);
+    }
+    uint32_t vol_block_size = vol->block_size_bytes;
+    uint64_t vol_size_bytes = vol->size_bytes;
+    char vol_name_copy[XSAN_MAX_NAME_LEN];
+    xsan_strcpy_safe(vol_name_copy, vol->name, XSAN_MAX_NAME_LEN);
+    pthread_mutex_unlock(&vm->lock);
+
+
+    if (current_vol_state == XSAN_STORAGE_STATE_OFFLINE || current_vol_state == XSAN_STORAGE_STATE_FAILED) {
+        XSAN_LOG_ERROR("Cannot write to volume '%s' (ID: %s), state is %d.",
+                       vol_name_copy, spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), current_vol_state);
+        return XSAN_ERROR_RESOURCE_UNAVAILABLE;
+    }
+    if (vol_block_size == 0 ||
+        (logical_byte_offset % vol_block_size != 0) ||
+        (length_bytes % vol_block_size != 0) ||
+        (logical_byte_offset + length_bytes > vol_size_bytes)) {
+        XSAN_LOG_ERROR("Write params invalid for vol %s: offset %lu, len %lu, vol_size %lu, blk_size %u",
+                        vol_name_copy, logical_byte_offset, length_bytes, vol_size_bytes, vol_block_size);
+        return XSAN_ERROR_INVALID_PARAM_ALIGNMENT;
+    }
+
+    if (current_actual_replica_count == 0) {
+        XSAN_LOG_ERROR("Volume '%s' (ID: %s) has no replicas configured for write.",
+                       vol_name_copy, spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]));
+        return XSAN_ERROR_REPLICATION_UNAVAILABLE;
+    }
+
+    static uint64_t s_wtid_ctr = 1000;
+    uint64_t transaction_id = __sync_fetch_and_add(&s_wtid_ctr, 1);
+
+    // Pass the original vol pointer to create, it will be used to read FTT, etc.
+    // The create function should not store it long-term if vol can be freed.
+    // Here, vol is from get_by_id, so it's a pointer to internal list, assumed valid.
+    xsan_replicated_io_ctx_t *rep_ctx = xsan_replicated_io_ctx_create(
+        user_cb, user_cb_arg, vol, user_buf, logical_byte_offset, length_bytes, transaction_id);
+
+    if (!rep_ctx) {
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+
+    pthread_mutex_lock(&vm->pending_ios_lock);
+    if (xsan_hashtable_put(vm->pending_replicated_ios, &rep_ctx->transaction_id, rep_ctx) != XSAN_OK) {
+        pthread_mutex_unlock(&vm->pending_ios_lock);
+        XSAN_LOG_ERROR("Failed to add TID %lu to pending replicated IOs hashtable.", transaction_id);
+        xsan_replicated_io_ctx_free(rep_ctx);
+        return XSAN_ERROR_OUT_OF_MEMORY;
+    }
+    pthread_mutex_unlock(&vm->pending_ios_lock);
+
+    XSAN_LOG_DEBUG("Starting replicated write for vol %s, TID %lu, offset %lu, len %lu, replicas %u",
+                   spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id,
+                   logical_byte_offset, length_bytes, current_actual_replica_count);
+
+    xsan_error_t submit_status;
+    bool at_least_one_submission_attempted = false;
+
+    for (uint32_t i = 0; i < current_actual_replica_count; ++i) {
+        xsan_replica_location_t *current_replica_loc = &replica_locations_copy[i];
+        bool should_attempt_write_to_replica = false;
+
+        if (current_replica_loc->state == XSAN_STORAGE_STATE_ONLINE || current_replica_loc->state == XSAN_STORAGE_STATE_DEGRADED) {
+            should_attempt_write_to_replica = true;
+        } else {
+             XSAN_LOG_WARN("Replica %u (NodeID: %s) for vol %s (TID %lu) is not in a writable state (state %d). Skipping write attempt to this replica.",
+                          i, spdk_uuid_get_string((struct spdk_uuid*)&current_replica_loc->node_id.data[0]),
+                          spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id, current_replica_loc->state);
+        }
+
+        if (!should_attempt_write_to_replica) {
+            // Simulate an immediate failure for this replica path to ensure rep_ctx is correctly managed.
+            // This is a simplification. A more robust system might have different handling.
+            if (i == 0) { // Local
+                 _xsan_local_replica_write_complete_cb(rep_ctx, XSAN_ERROR_RESOURCE_UNAVAILABLE);
+            } else { // Remote
+                // Create a dummy context just to call the failure path of send_actual_cb
+                xsan_per_replica_op_ctx_t *dummy_remote_ctx = XSAN_MALLOC(sizeof(xsan_per_replica_op_ctx_t));
+                if (dummy_remote_ctx) {
+                    memset(dummy_remote_ctx, 0, sizeof(xsan_per_replica_op_ctx_t));
+                    dummy_remote_ctx->parent_rep_ctx = rep_ctx;
+                    memcpy(&dummy_remote_ctx->replica_location_info, current_replica_loc, sizeof(xsan_replica_location_t));
+                    _xsan_remote_replica_request_send_actual_cb(XSAN_ERROR_RESOURCE_UNAVAILABLE, dummy_remote_ctx);
+                    // _xsan_remote_replica_request_send_actual_cb will free dummy_remote_ctx.
+                } else { // Failed to alloc dummy, just count as failed write for rep_ctx
+                    __sync_fetch_and_add(&rep_ctx->failed_writes, 1);
+                     if (rep_ctx->final_status == XSAN_OK) rep_ctx->final_status = XSAN_ERROR_RESOURCE_UNAVAILABLE;
+                     _xsan_check_replicated_write_completion(rep_ctx); // Check if this completes the whole op
+                }
+            }
+            continue;
+        }
+        at_least_one_submission_attempted = true;
+
+        if (i == 0) {
+            submit_status = _xsan_volume_submit_single_io_attempt(
+                vm, volume_id, logical_byte_offset, length_bytes,
+                (void*)user_buf,
+                false,
+                _xsan_local_replica_write_complete_cb,
+                rep_ctx);
+
+            if (submit_status != XSAN_OK) {
+                XSAN_LOG_ERROR("Failed to submit local write for vol %s, TID %lu: %s",
+                               spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id, xsan_error_string(submit_status));
+                _xsan_local_replica_write_complete_cb(rep_ctx, submit_status);
+            }
+        } else {
+            xsan_per_replica_op_ctx_t *remote_op_ctx = XSAN_MALLOC(sizeof(xsan_per_replica_op_ctx_t));
+            if (!remote_op_ctx) {
+                 XSAN_LOG_ERROR("Failed to allocate per_replica_op_ctx for vol %s, TID %lu, replica %u",
+                               spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id, i);
+                __sync_fetch_and_add(&rep_ctx->failed_writes, 1);
+                if (rep_ctx->final_status == XSAN_OK) rep_ctx->final_status = XSAN_ERROR_OUT_OF_MEMORY;
+                _xsan_check_replicated_write_completion(rep_ctx);
+                continue;
+            }
+            memset(remote_op_ctx, 0, sizeof(xsan_per_replica_op_ctx_t));
+            remote_op_ctx->parent_rep_ctx = rep_ctx;
+            memcpy(&remote_op_ctx->replica_location_info, current_replica_loc, sizeof(xsan_replica_location_t));
+
+            xsan_replica_write_req_payload_t write_req_pl;
+            memcpy(&write_req_pl.volume_id, &volume_id, sizeof(xsan_volume_id_t));
+            write_req_pl.block_lba_on_volume = logical_byte_offset / vol_block_size;
+            write_req_pl.num_blocks = length_bytes / vol_block_size;
+
+            remote_op_ctx->request_msg_to_send = xsan_protocol_message_create_with_data(
+                XSAN_MSG_TYPE_REPLICA_WRITE_BLOCK_REQ,
+                transaction_id,
+                &write_req_pl, sizeof(write_req_pl),
+                user_buf, length_bytes);
+
+            if (!remote_op_ctx->request_msg_to_send) {
+                XSAN_LOG_ERROR("Failed to create replica write message for vol %s, TID %lu, replica %u",
+                               spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id, i);
+                XSAN_FREE(remote_op_ctx);
+                __sync_fetch_and_add(&rep_ctx->failed_writes, 1);
+                if (rep_ctx->final_status == XSAN_OK) rep_ctx->final_status = XSAN_ERROR_OUT_OF_MEMORY;
+                 _xsan_check_replicated_write_completion(rep_ctx);
+                continue;
+            }
+
+            struct spdk_sock *sock = xsan_node_comm_get_active_connection(
+                current_replica_loc->node_ip_addr, current_replica_loc->node_comm_port);
+
+            if (sock) {
+                _xsan_remote_replica_connect_then_send_cb(sock, 0, remote_op_ctx);
+            } else {
+                xsan_node_comm_connect(current_replica_loc->node_ip_addr,
+                                       current_replica_loc->node_comm_port,
+                                       _xsan_remote_replica_connect_then_send_cb,
+                                       remote_op_ctx);
+            }
+        }
+    }
+
+    if (!at_least_one_submission_attempted && current_actual_replica_count > 0) {
+        XSAN_LOG_ERROR("Vol %s, TID %lu: No replicas were in a state to attempt writes.",
+            spdk_uuid_get_string((struct spdk_uuid*)&volume_id.data[0]), transaction_id);
+        rep_ctx->final_status = XSAN_ERROR_REPLICATION_UNAVAILABLE;
+        for(uint32_t k=0; k < rep_ctx->total_replicas_targeted; ++k) {
+            __sync_fetch_and_add(&rep_ctx->failed_writes, 1);
+        }
+        _xsan_check_replicated_write_completion(rep_ctx);
+        return XSAN_ERROR_REPLICATION_UNAVAILABLE;
+    } else if (current_actual_replica_count == 0) { // Should have been caught earlier
+         xsan_replicated_io_ctx_free(rep_ctx);
+         return XSAN_ERROR_REPLICATION_UNAVAILABLE;
+    }
+
+
+    return XSAN_OK;
+}

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -590,6 +590,15 @@ bool xsan_config_load_node_config(xsan_config_t *config, xsan_node_config_t *nod
                      xsan_config_get_string(config, "node.ssl_key_file", ""), 
                      sizeof(node_config->ssl_key_file));
     
+    // Load NVMe-oF target specific config (optional)
+    xsan_strcpy_safe(node_config->nvmf_target_nqn,
+                     xsan_config_get_string(config, "nvmf.target_nqn", ""), // Default to empty, nvmf_target_init will use default
+                     sizeof(node_config->nvmf_target_nqn));
+
+    xsan_strcpy_safe(node_config->nvmf_listen_port,
+                     xsan_config_get_string(config, "nvmf.listen_port", "4420"), // Default NVMe-oF TCP port
+                     sizeof(node_config->nvmf_listen_port));
+
     return true;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Enable testing for the project
+enable_testing()
+
+# Ensure CUnit is found. This should ideally be in the root CMakeLists.txt
+# find_package(CUnit REQUIRED)
+# If not found globally, you might need to specify its include dirs and libs manually or use pkg-config.
+# For now, assume CUnit headers are findable and 'cunit' is the link library name.
+
+# --- Test for Infrastructure (example, based on existing test_infrastructure.c) ---
+add_executable(xsan_test_infrastructure test_infrastructure.c)
+
+target_link_libraries(xsan_test_infrastructure PRIVATE
+    xsan_common  # Assuming test_infrastructure uses common types/error codes
+    xsan_utils   # Assuming test_infrastructure uses logging or memory utils
+    # Add any other specific xsan libraries test_infrastructure.c needs
+    cunit        # Link against CUnit
+    Threads::Threads # For pthreads if needed
+)
+
+target_include_directories(xsan_test_infrastructure PRIVATE
+    ${CMAKE_SOURCE_DIR}/include      # For xsan_types.h
+    ${CMAKE_SOURCE_DIR}/src/include  # For internal headers like xsan_config.h if used by utils
+)
+
+add_test(NAME XsanInfrastructureTest COMMAND xsan_test_infrastructure)
+
+
+# --- Test for Cluster module (xsan_get_local_node_info) ---
+add_executable(xsan_test_cluster test_cluster.c)
+
+target_link_libraries(xsan_test_cluster PRIVATE
+    xsan_cluster  # The library we are testing
+    xsan_utils    # For xsan_config.c (linked by xsan_utils) and xsan_log.h, xsan_string_utils.h
+    xsan_common   # For xsan_error_t
+    cunit         # CUnit library
+    Threads::Threads
+    # Link SPDK libraries needed by xsan_cluster.c (e.g., for spdk_uuid_parse)
+    # XSAN_SPDK_LIBRARIES should be available from the root CMakeLists.txt
+    # It typically includes spdk_util which has uuid functions.
+    ${XSAN_SPDK_LIBRARIES}
+)
+
+target_include_directories(xsan_test_cluster PRIVATE
+    ${CMAKE_SOURCE_DIR}/include       # For xsan_types.h, xsan_cluster.h
+    ${CMAKE_SOURCE_DIR}/src/include   # For xsan_config.h (used by xsan_cluster.c indirectly)
+    # SPDK include directories are globally added in the root CMakeLists.txt
+)
+
+add_test(NAME XsanClusterGetLocalNodeInfoTest COMMAND xsan_test_cluster)
+
+# Add more tests here in the future in a similar manner.
+# Example:
+# add_executable(xsan_test_storage test_storage.c)
+# target_link_libraries(xsan_test_storage PRIVATE xsan_storage xsan_disk_manager xsan_volume_manager cunit Threads::Threads ${XSAN_SPDK_LIBRARIES})
+# target_include_directories(xsan_test_storage PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src/include)
+# add_test(NAME XsanStorageTests COMMAND xsan_test_storage)

--- a/tests/test_cluster.c
+++ b/tests/test_cluster.c
@@ -1,0 +1,151 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "CUnit/Basic.h"
+
+#include "xsan_cluster.h"
+#include "xsan_config.h" // For xsan_node_config_t definition
+#include "xsan_error.h"
+#include "spdk/uuid.h"
+#include "xsan_log.h" // To initialize logging for modules that use it
+
+// External global variables defined in xsan_node.c (or other main module)
+// We need to provide definitions for them for the test linker.
+// In a real test setup, you might have a mock or test-specific main.
+xsan_config_t *g_xsan_config = NULL;
+xsan_node_config_t g_local_node_config;
+// xsan_cluster_config_t g_cluster_config; // Not directly used by xsan_get_local_node_info test
+
+// Mock implementation for xsan_log_init or ensure it's called if necessary
+// For simplicity, we might not need full logging in unit tests or can stub it.
+
+int suite_cluster_init(void) {
+    // Initialize logging if modules depend on it for error reporting
+    // xsan_log_init("test_cluster.log", XSAN_LOG_LEVEL_DEBUG, false);
+
+    // Initialize g_xsan_config for tests that might check it
+    // This is a simplified setup. A real test might load a test config file.
+    g_xsan_config = xsan_config_create(); // So it's not NULL
+    if (!g_xsan_config) return -1;
+    return 0;
+}
+
+int suite_cluster_clean(void) {
+    if (g_xsan_config) {
+        xsan_config_destroy(g_xsan_config);
+        g_xsan_config = NULL;
+    }
+    // xsan_log_fini();
+    return 0;
+}
+
+void test_get_local_node_info_uninitialized(void) {
+    xsan_node_id_t node_id;
+    char ip_buf[64];
+    uint16_t port;
+
+    // Simulate uninitialized config (node_id string is empty)
+    memset(&g_local_node_config, 0, sizeof(xsan_node_config_t));
+
+    xsan_error_t ret = xsan_get_local_node_info(&node_id, ip_buf, sizeof(ip_buf), &port);
+    CU_ASSERT_EQUAL(ret, XSAN_ERROR_NOT_INITIALIZED);
+}
+
+void test_get_local_node_info_valid_config(void) {
+    xsan_node_id_t node_id;
+    char ip_buf[64];
+    uint16_t port;
+    const char *test_uuid_str = "a1b2c3d4-e5f6-7788-9900-aabbccddeeff";
+    struct spdk_uuid expected_uuid;
+    CU_ASSERT_EQUAL(spdk_uuid_parse(&expected_uuid, test_uuid_str), 0);
+
+    // Setup g_local_node_config with valid data
+    strncpy(g_local_node_config.node_id, test_uuid_str, sizeof(g_local_node_config.node_id) -1);
+    g_local_node_config.node_id[sizeof(g_local_node_config.node_id) -1] = '\0';
+    strncpy(g_local_node_config.bind_address, "192.168.1.100", sizeof(g_local_node_config.bind_address));
+    g_local_node_config.port = 8080;
+    // Ensure g_xsan_config is not NULL to pass the first check in xsan_get_local_node_info
+    if (!g_xsan_config) { g_xsan_config = xsan_config_create(); }
+
+
+    xsan_error_t ret = xsan_get_local_node_info(&node_id, ip_buf, sizeof(ip_buf), &port);
+    CU_ASSERT_EQUAL(ret, XSAN_OK);
+    CU_ASSERT_EQUAL(spdk_uuid_compare((struct spdk_uuid*)node_id.data, &expected_uuid), 0);
+    CU_ASSERT_STRING_EQUAL(ip_buf, "192.168.1.100");
+    CU_ASSERT_EQUAL(port, 8080);
+}
+
+void test_get_local_node_info_invalid_uuid_string(void) {
+    xsan_node_id_t node_id;
+    char ip_buf[64];
+    uint16_t port;
+
+    strncpy(g_local_node_config.node_id, "not-a-uuid", sizeof(g_local_node_config.node_id));
+    strncpy(g_local_node_config.bind_address, "10.0.0.1", sizeof(g_local_node_config.bind_address));
+    g_local_node_config.port = 7070;
+    if (!g_xsan_config) { g_xsan_config = xsan_config_create(); }
+
+
+    xsan_error_t ret = xsan_get_local_node_info(&node_id, ip_buf, sizeof(ip_buf), &port);
+    CU_ASSERT_EQUAL(ret, XSAN_ERROR_CONFIG_PARSE);
+}
+
+void test_get_local_node_info_empty_ip_or_port(void) {
+    xsan_node_id_t node_id;
+    char ip_buf[64];
+    uint16_t port;
+    const char *test_uuid_str = "a1b2c3d4-e5f6-7788-9900-aabbccddeeff";
+
+    strncpy(g_local_node_config.node_id, test_uuid_str, sizeof(g_local_node_config.node_id));
+    g_local_node_config.bind_address[0] = '\0'; // Empty IP
+    g_local_node_config.port = 8080;
+    if (!g_xsan_config) { g_xsan_config = xsan_config_create(); }
+
+    xsan_error_t ret = xsan_get_local_node_info(&node_id, ip_buf, sizeof(ip_buf), &port);
+    CU_ASSERT_EQUAL(ret, XSAN_ERROR_CONFIG_INVALID);
+
+    strncpy(g_local_node_config.bind_address, "10.0.0.1", sizeof(g_local_node_config.bind_address));
+    g_local_node_config.port = 0; // Invalid port
+    ret = xsan_get_local_node_info(&node_id, ip_buf, sizeof(ip_buf), &port);
+    // Depending on strictness in xsan_get_local_node_info, 0 port might be warning or XSAN_ERROR_CONFIG_INVALID
+    // Current xsan_cluster.c logs a warning for port 0 but returns XSAN_OK.
+    // For a strict test, we might want it to be an error. Let's assume it's OK for now per implementation.
+    // CU_ASSERT_EQUAL(ret, XSAN_ERROR_CONFIG_INVALID);
+    // Based on current xsan_cluster.c, it returns OK and logs warning.
+     CU_ASSERT_EQUAL(ret, XSAN_OK);
+     CU_ASSERT_EQUAL(port, 0);
+
+}
+
+
+int main(void) {
+    CU_pSuite pSuite = NULL;
+
+    if (CUE_SUCCESS != CU_initialize_registry()) {
+        return CU_get_error();
+    }
+
+    pSuite = CU_add_suite("Cluster_Utils_Suite", suite_cluster_init, suite_cluster_clean);
+    if (NULL == pSuite) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    if ((NULL == CU_add_test(pSuite, "test_get_local_node_info_uninitialized", test_get_local_node_info_uninitialized)) ||
+        (NULL == CU_add_test(pSuite, "test_get_local_node_info_valid_config", test_get_local_node_info_valid_config)) ||
+        (NULL == CU_add_test(pSuite, "test_get_local_node_info_invalid_uuid_string", test_get_local_node_info_invalid_uuid_string)) ||
+        (NULL == CU_add_test(pSuite, "test_get_local_node_info_empty_ip_or_port", test_get_local_node_info_empty_ip_or_port))
+       ) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    CU_basic_set_mode(CU_BRM_VERBOSE);
+    CU_basic_run_tests();
+
+    int failures = CU_get_number_of_failures();
+    CU_cleanup_registry();
+
+    return failures > 0 ? 1 : 0; // Return 1 if any test failed, 0 otherwise
+}


### PR DESCRIPTION
This commit introduces several key features and enhancements to the XSAN storage backend:

Core Storage Engine (Volume Management):
- Implemented full lifecycle management for volumes (create, delete, get, list) with metadata persistence using RocksDB. Volume information is serialized to JSON before being stored.
- Added a preliminary LBA-to-physical mapping function (`xsan_volume_map_lba_to_physical`), currently mapping linearly to the first disk of a group.
- Implemented an internal physical I/O submission helper (`_xsan_volume_submit_single_io_attempt`) and its associated callback (`_xsan_physical_io_complete_cb`) to abstract direct bdev I/O submission for volume operations.
- Completed the implementation of `xsan_volume_write_async` for replicated writes, leveraging the new I/O submission helper and existing replication context framework.
- Improved locking for concurrent access in replication-related callbacks.

Data Replication & Consistency:
- Defined `xsan_per_replica_op_ctx_t` for tracking per-replica operations.
- Implemented context management functions (`_create`/`_free`) for `xsan_replicated_io_ctx_t` and `xsan_replica_read_coordinator_ctx_t` in `xsan_replication.c`.
- Updated CMake files for the replication module.

Cluster Management Basics:
- Added global configuration loading in `xsan_node.c` from a specified config file (default `xsan_node.conf`), parsing node and cluster settings.
- Implemented `xsan_get_local_node_info()` in `xsan_cluster.c` to provide local node ID (UUID), IP, and port from the loaded configuration, replacing the placeholder in `volume_manager.c`.
- Updated CMake files for the cluster module.

Testing:
- Added unit tests for `xsan_get_local_node_info()` in `test_cluster.c`.
- Configured `tests/CMakeLists.txt` to build and register the new tests.

This work lays a significant foundation for further backend development, including more sophisticated block allocation, full I/O path implementation for `xsan_io.c`, and advanced cluster features.